### PR TITLE
Change cookbook name in include_recipe call

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "sensu::default"
+include_recipe "sensu-chef::default"
 
 service "sensu-client" do
   provider node.platform =~ /ubuntu|debian/ ? Chef::Provider::Service::Init::Debian : Chef::Provider::Service::Init::Redhat

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "sensu::default"
+include_recipe "sensu-chef::default"
 
 remote_directory File.join(node.sensu.directory, "handlers") do
   files_mode 0755


### PR DESCRIPTION
I think the include_recipe "sensu::default" calls in server.rb and client.rb are supposed to be include_recipe "sensu-chef::default".  Maybe the cookbook name changed recently?
