### PR TITLE
Adding name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "sensu"
 maintainer       "Sonian, Inc."
 maintainer_email "chefs@sonian.net"
 license          "Apache 2.0"


### PR DESCRIPTION
If users are cloning the repo directly, without this attribute the chef server will infer the name from the directory (which will be "sensu-chef" and this will break the include_recipe statements in the cookbook
