### PR TITLE
Fixed issue where a json-file got filled with ruby data instead of json ...

### DIFF
--- a/libraries/json_file.rb
+++ b/libraries/json_file.rb
@@ -15,9 +15,16 @@ class Chef::Provider::JsonFile < Chef::Provider::File
     unless compare_content
       backup @new_resource.path if ::File.exists?(@new_resource.path)
       ::File.open(@new_resource.path, "w") {|f| f.write dump_json(@new_resource.content) }
-      Chef::Log.info("#{@new_resource} contents updated")
+      Chef::Log.info("#{@new_resource} updated file #{@new_resource.path}")
       @new_resource.updated_by_last_action(true)
     end
+  end
+
+  def action_create
+    set_content unless @new_resource.content.nil?
+    set_owner unless @new_resource.owner.nil?
+    set_group unless @new_resource.group.nil?
+    set_mode unless @new_resource.mode.nil?
   end
 end
 


### PR DESCRIPTION
This happened when the file was initially created (at least in Chef 0.10.8). It happened because action_create wrote the content variable directory to the file (thus bypassing set_content).

Also changed the log message to match the one issued by the File resource (include path)
