### PR TITLE
Sensu gem resource

### DIFF
--- a/libraries/sensu_gem.rb
+++ b/libraries/sensu_gem.rb
@@ -8,6 +8,8 @@ class Chef::Resource::SensuGem < Chef::Resource::GemPackage
   def gem_binary
     if(::File.exists?('/opt/sensu/embedded/bin/gem'))
       '/opt/sensu/embedded/bin/gem'
+    else
+      'gem'
     end
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -53,7 +53,7 @@ else
   end
 end
 
-gem_package "sensu-plugin" do
+sensu_gem "sensu-plugin" do
   version node.sensu.plugin.version
 end
 


### PR DESCRIPTION
Add resource for sensu gem to install gem dependencies into sensu provided ruby. This goes along with this pull request:

https://github.com/sensu/sensu-build/pull/8

allowing the handlers and plugins to use the embedded ruby if available rather than the system ruby.
