### PR TITLE
on rhel family use node.platform_version to build repo url

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,7 +37,7 @@ when "centos", "redhat"
 
   yum_repository "sensu" do
     repo = node.sensu.package.unstable ? "yum-unstable" : "yum"
-    url "http://repos.sensuapp.org/#{repo}/el/$releasever/$basearch/"
+    url "http://repos.sensuapp.org/#{repo}/el/#{node['platform_version'].to_i}/$basearch/"
     action :add
   end
 end


### PR DESCRIPTION
This was needed in the case of rhel 5.5 where `$releasever` was actually `5Server` instead of `5` as expected

Tested Platform:
Red Hat Enterprise Linux Server release 5.5 (Tikanga)

Yum vars:
{'arch': 'ia32e',
 'basearch': 'x86_64',
 'releasever': '5Server'}
