### PR TITLE
Use sensu_gem instead of gem_package for deps.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ unless node.platform == "windows"
     options package_options
   end
 else
-  gem_package "sensu" do
+  sensu_gem "sensu" do
     version node.sensu.version.split("-").first
   end
 end

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -17,10 +17,10 @@
 # limitations under the License.
 #
 
-gem_package "sensu-plugin" do
+sensu_gem "sensu-plugin" do
   version node.sensu.plugin.version
 end
 
 # handler & plugin dependencies
 # eg. node.sensu.client.foo = "bar"
-# eg. gem_package "spice"
+# eg. sensu_gem "spice"


### PR DESCRIPTION
I changed the dependencies and default recipes to use the provided "sensu_gem" instead of Chef's "gem_package". This allowed the installation to function correctly with out system wide install of Ruby. 
