### PR TITLE
Detect ip address if not detected properly

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -102,7 +102,11 @@ else
 end
 
 sensu_config node.name do
-  address node.has_key?(:cloud) ? node.cloud.public_ipv4 : node.ipaddress
+  if node.has_key?(:cloud)
+    address node.cloud.public_ipv4 || node.ipaddress
+  else
+    address node.ipaddress
+  end
   subscriptions node.roles
   data_bag data_bag_item("sensu", "config")
 end


### PR DESCRIPTION
#### public_ipv4 can get defined as nil in some cases, or in my case I looked like this when sensu-client was exiting with non-zero codes:

![OMG](http://f.cl.ly/items/0A3Z2E2H1W1z2n3g1Z1W/JCZoc.gif)
### So specifically, in my case, I'm on a Linode system. OHAI currently sees it as a 'rackspace' node, which throws off its ipv4 address detection. The 'cloud' section of the node attributes gets defined, but with a nil ip4 address, which then blows up the sensu-client when it writes a null to the config file for address.
### This pull request will do a minor change to detect this nil and make everything happy, like so:

![YAY](http://f.cl.ly/items/1L1T1H282N05263v1l22/4NYwh.gif)
