### PR TITLE
Allow all items inside data bag to make up config

### DIFF
--- a/providers/config.rb
+++ b/providers/config.rb
@@ -2,9 +2,12 @@ action :create do
   attributes_config = node.sensu.to_hash.reject do |key, value|
     %w[package plugin directory log ssl sudoers firewall].include?(key)
   end
-  data_bag_config = @new_resource.data_bag.reject do |key, value|
-    %w[id chef_type data_bag].include?(key)
-  end
+  data_bag_config = {}
+  data_bag(@new_resource.data_bag).each do |bag_item|
+    data_bag_config = Chef::Mixin::DeepMerge.merge(data_bag_config, data_bag_item(@new_resource.data_bag, bag_item).reject do |key, value|
+      %w[id chef_type data_bag].include?(key)
+    end)
+  end 
   client_config = {
     :client => {
       :name => @new_resource.name,

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -2,7 +2,7 @@ actions :create, :updated
 
 attribute :address, :kind_of => String
 attribute :subscriptions, :kind_of => Array
-attribute :data_bag
+attribute :data_bag, :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
In larger installations, it seems more logical to split up the check and handler configs into separate data bag items instead of everything going into the single item, e.g. system_checks.json, postgres_checks.json, etc.  This change will build the config from all of the items in the data bag.
