### PR TITLE
initial support for fedora

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -26,6 +26,7 @@ recommends "iptables"
   debian
   centos
   redhat
+  fedora
   windows
 ].each do |os|
   supports os


### PR DESCRIPTION
this includes support for installing the proper sensu omnibus package on fedora. We do this by mapping the fedora version to the RHEL version, since the yum repo directory structure is currently based on rhel versions.

TODO in the future.  Use systemd .service units on fedora boxes. For now, the init scripts should work, but ideally fedora boxes should just use the simpler systemd service units which are shipped in the omnibus package as extras in the `/usr/share/` dir.
