### PR TITLE
ensuring sensu_api_stash payloads are properly formatted

### DIFF
--- a/libraries/sensu_api.rb
+++ b/libraries/sensu_api.rb
@@ -29,10 +29,10 @@ module Sensu
         end 
       end
 
-      def post(path, payload)
+      def post(path,payload={})
         req = Net::HTTP::Post.new(path, {'Content-Type'=>'application/json'})
 
-        req.body = payload
+        req.body = payload.to_json.to_s
 
         response = Net::HTTP.start(@server_uri.host, @server_uri.port) do |http|
           http.request(req)


### PR DESCRIPTION
The payload hash was being sent as the request body without being converted to JSON. With this fix the payload will now be converted to JSON (and then to a string) when generating the request body.
