### PR TITLE
rabbitmq recipe - syntax fix for older Chef versions

### DIFF
--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -49,7 +49,7 @@ include_recipe "rabbitmq::mgmt_console"
 service "restart #{node.rabbitmq.service_name}" do
   service_name node.rabbitmq.service_name
   action :nothing
-  subscribes :restart, "template[#{node.rabbitmq.config_root}/rabbitmq.config]", :immediately
+  subscribes :restart, resources("template[#{node.rabbitmq.config_root}/rabbitmq.config]"), :immediately
 end
 
 rabbitmq_vhost node.sensu.rabbitmq.vhost do


### PR DESCRIPTION
See https://github.com/sensu/sensu-chef/commit/176b7c52746f6306ade627edc1990a4783083819
Since it's verified to not work below 10.14.0, and this is the documented syntax - let's just put it in I guess...

Cheers,
Elad
