### PR TITLE
[rabbitmq] perms can be a single string instead of multi-quoted

### DIFF
--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -63,6 +63,6 @@ end
 
 rabbitmq_user node.sensu.rabbitmq.user do
   vhost node.sensu.rabbitmq.vhost
-  permissions "\".*\" \".*\" \".*\""
+  permissions ".* .* .*"
   action :set_permissions
 end


### PR DESCRIPTION
Tested on ubuntu 12.04, where multi-quoted string had oddly failed
