### PR TITLE
Remove nil values & empty hashes under base_config

### DIFF
--- a/libraries/sensu_definitions.rb
+++ b/libraries/sensu_definitions.rb
@@ -1,0 +1,29 @@
+module SensuDefinitions
+  class << self
+    def sanitize(definition, options = {})
+      # By default, don't remove levels of hierarchy (empty hashes) the code might expect
+      options = {
+        :master_keys => nil,
+        :allow_empty_hash => true
+      }.merge(options)
+      sub_options = options.merge({:master_keys => nil})
+
+      if definition.is_a?(Hash)
+        new_definition = Mash.new
+        definition.each do |key, value|
+          if options[:master_keys].nil? || options[:master_keys].include?(key.to_s)
+            new_value = sanitize(value, sub_options)
+            new_definition[key] = new_value unless new_value.nil?
+          end
+        end
+        if !new_definition.empty? || options[:allow_empty_hash]
+          new_definition
+        else
+          nil
+        end
+      else
+        definition
+      end
+    end
+  end
+end

--- a/providers/base_config.rb
+++ b/providers/base_config.rb
@@ -1,22 +1,7 @@
 action :create do
-  definitions = node.sensu.to_hash.reject do |key, value|
-    !%w[rabbitmq redis api dashboard].include?(key.to_s) || value.nil?
-  end
-
-  def clean_config(config_value)
-    if config_value.is_a?(Hash)
-      clean_hash = Hash.new
-      config_value.each do |key, value|
-        new_value = clean_config(value)
-        clean_hash[key] = new_value unless new_value.nil?
-      end
-      clean_hash.empty? ? nil : clean_hash
-    else
-      config_value
-    end
-  end
-
-  definitions = clean_config(definitions)
+  definitions = SensuDefinitions::sanitize(node.sensu.to_hash, 
+                  :master_keys => %w[rabbitmq redis api dashboard],
+                  :allow_empty_hash => false)
 
   sensu_json_file ::File.join(node.sensu.directory, "config.json") do
     mode 0644

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -1,11 +1,12 @@
 action :create do
-  check = new_resource.to_hash.reject { |key, value|
-    !%w[type command subscribers standalone handlers].include?(key.to_s) || value.nil?
-  }.merge("interval" => new_resource.interval)
+  check = SensuDefinitions.sanitize(new_resource.to_hash, 
+            :master_keys => %w[type command subscribers standalone handlers]).
+              merge("interval" => new_resource.interval).
+                merge(new_resource.additional)
 
   definition = {
     "checks" => {
-      new_resource.name => check.merge(new_resource.additional)
+      new_resource.name => check
     }
   }
 

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -1,9 +1,8 @@
 action :create do
   definition = {
     "filters" => {
-      new_resource.name => new_resource.to_hash.reject { |key, value|
-        !%w[attributes negate].include?(key.to_s) || value.nil?
-      }
+      new_resource.name => SensuDefinitions.sanitize(new_resource.to_hash,
+                             :master_keys => %w[attributes negate])
     }
   }
 

--- a/providers/handler.rb
+++ b/providers/handler.rb
@@ -1,9 +1,9 @@
 action :create do
   definition = {
     "handlers" => {
-      new_resource.name => new_resource.to_hash.reject { |key, value|
-        !%w[type filters mutator severities handlers command socket exchange].include?(key.to_s) || value.nil?
-      }.merge(new_resource.additional)
+      new_resource.name => SensuDefinitions.sanitize(new_resource.to_hash,
+                             :master_keys => %w[type filters mutator severities handlers command socket exchange]).
+                               merge(new_resource.additional)
     }
   }
 


### PR DESCRIPTION
See https://github.com/sensu/sensu-chef/commit/074c30488354f001d53185b027d00158c09ef9ed @martinisoft

Code is more verbose than I'd like, so comments welcome. There are some fine points here, but perhaps we can simplify.
- I put it under base_config only, as in other providers (check, handler, snippet) users might rely on levels of hierarchy to exist even if empty.
- The code does not remove all 'empty' variables, just empty hashes. An empty string might mean something, but I think a nil value should not, at least in the context of base_config. 
