### PR TITLE
Chef run failed due to undefined defautl_action 

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant::Config.run do |config|
     "--memory", "1024"
   ]
 
-  config.vm.provision :shell, :inline => "command -v chef-solo || curl -L https://www.opscode.com/chef/install.sh | bash"
+  config.vm.provision :shell, :inline => "curl -L https://www.opscode.com/chef/install.sh | bash"
 
   config.vm.forward_port 8080, 8080
   config.vm.forward_port 9000, 9000


### PR DESCRIPTION
For the image being used ubuntu-1204-i386, it has an older version of chef-solo which does not have "default_action" defined, so chef run will break at compile time. For people using the image they have to reinstall chef-client
