### PR TITLE
[redis] update to match chef-redis 2.0 attributes

### DIFF
--- a/recipes/redis.rb
+++ b/recipes/redis.rb
@@ -21,9 +21,11 @@ node.set.redis.config.bind = "0.0.0.0"
 node.set.redis.config.port = node.sensu.redis.port
 
 if node.platform == "ubuntu" && node.platform_version <= "10.04"
-  include_recipe "redis::server_source"
+  node.set.redis.install_type = "source"
 elsif node.platform == "debian"
-  include_recipe "redis::server_source"
+  node.set.redis.install_type = "source"
 else
-  include_recipe "redis::server_package"
+  node.set.redis.install_type = "package"
 end
+
+include_recipe "redis::server"


### PR DESCRIPTION
In redis 2.0 we renamed these attributes.
https://github.com/miah/chef-redis/blob/master/attributes/config.rb#L8-L9
