### PR TITLE
Allow using existing rabbitmq, existing repo config

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Enables and starts the Sensu dashboard.
 `node.sensu.use_unstable_repo` - If the build resides on the
 "unstable" repository.
 
+`node.sensu.use_existing_repo` - If a sensu repository is already configured
+(e.g. when you have a mirror repo or need a custom repo for proxy configuration)
+
 `node.sensu.directory` - Sensu configuration directory.
 
 `node.sensu.log_directory` - Sensu log directory.
@@ -102,6 +105,9 @@ Enables and starts the Sensu dashboard.
 
 `node.sensu.use_embedded_ruby` - If Sensu Ruby handlers and plugins
 are to use the embedded Ruby in the monolithic package.
+
+`node.sensu.use_existing_rabbitmq` - If a non chef-installed RabbitMQ already
+exists on the server (e.g. when installing on a chef-server machine)
 
 ### RabbitMQ
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,10 +1,12 @@
 # installation
 default.sensu.version = "0.9.11-1"
 default.sensu.use_unstable_repo = false
+default.sensu.use_existing_repo = false
 default.sensu.directory = "/etc/sensu"
 default.sensu.log_directory = "/var/log/sensu"
 default.sensu.use_ssl = true
 default.sensu.use_embedded_ruby = false
+default.sensu.use_existing_rabbitmq = false
 
 # rabbitmq
 default.sensu.rabbitmq.host = "localhost"

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -43,13 +43,15 @@ if node.sensu.use_ssl
   end
 end
 
-include_recipe "rabbitmq"
-include_recipe "rabbitmq::mgmt_console"
+unless node.sensu.use_existing_rabbitmq
+  include_recipe "rabbitmq"
+  include_recipe "rabbitmq::mgmt_console"
 
-service "restart #{node.rabbitmq.service_name}" do
-  service_name node.rabbitmq.service_name
-  action :nothing
-  subscribes :restart, resources("template[#{node.rabbitmq.config_root}/rabbitmq.config]"), :immediately
+  service "restart #{node.rabbitmq.service_name}" do
+    service_name node.rabbitmq.service_name
+    action :nothing
+    subscribes :restart, resources("template[#{node.rabbitmq.config_root}/rabbitmq.config]"), :immediately
+  end
 end
 
 rabbitmq_vhost node.sensu.rabbitmq.vhost do


### PR DESCRIPTION
Hi,
Two additions for playing nicely with landscapes quirks:
1. When installing sensu-server on a chef-server machine and using the rabbitmq recipe, it fucks up the existing rabbitmq, so I added an option to just configure the existing install.
2. If you have to specially set-up the sensu repo config with proxy settings, or have mirrors set-up for important stuff (we currently do), I added an option not to create the 'sensu' repo but just install from the already configured one.

Question is: these additions add complexity to sensu-chef. Maybe the right approach is in this case is different?
I mean: for no.1, I might just not call sensu::rabbitmq, but instead duplicate the vhost/user/perms stuff in my own cookbook.
For no. 2, currently the _linux recipe is always called, but I could make sure to install the package from the correct source before this recipe is called.

If you think these are corner cases that should not be included, I'd take the alternative approach through my wrapper cookbook.
