### PR TITLE
[stash-format] Use key named "owner" instead of "actor" when creating stashes

### DIFF
--- a/definitions/silence_check.rb
+++ b/definitions/silence_check.rb
@@ -5,9 +5,9 @@ define :sensu_silence_check, :action => :create, :payload => {} do
   end
 
   if params[:action] == :create or params[:action] == :silence
-    # add a timestamp and actor to the payload 
+    # add a timestamp and owner to the payload
     # when we look at the stash later, these bits helps us know how old a stash is and how it got there
-    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'actor' => 'chef'})
+    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'owner' => 'chef'})
 
     sensu_api_stash "silence/#{params[:client]}/#{params[:name]}" do
       api_uri params[:api_uri]

--- a/definitions/silence_client.rb
+++ b/definitions/silence_client.rb
@@ -1,9 +1,9 @@
 define :sensu_silence_client, :action => :create, :payload => {} do
   if params[:action] == :create or params[:action] == :silence
-    # add a timestamp and actor to the payload
+    # add a timestamp and owner to the payload
     # when we look at the stash later, these bits helps us know how old a stash is and how it got there
-    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'actor' => 'chef'})
-    
+    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'owner' => 'chef'})
+
     sensu_api_stash "silence/#{params[:name]}" do
       api_uri params[:api_uri]
       payload merged_payload


### PR DESCRIPTION
This change causes the silence stashes created by this cookbook's LWRP to use the
'owner' key to indicate who set the stash, instead of the 'actor' key. Using 'owner' is consistent with how stashes set by sensu-admin are set.
