### PR TITLE
Add repo name attribute on rhel

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -53,6 +53,7 @@ when "fedora"
   end
 
   yum_repository "sensu" do
+    description "sensu monitoring"
     repo = node.sensu.use_unstable_repo ? "yum-unstable" : "yum"
     url "http://repos.sensuapp.org/#{repo}/el/#{rhel_version_equivalent}/$basearch/"
     action :add


### PR DESCRIPTION
Avoid the message "Repository 'sensu' is missing name in configuration, using id" in RHEL family when running yum commands by setting the name attribute in the generated .repo file
