### PR TITLE
Ubuntu 12.04 should be source, not package

### DIFF
--- a/recipes/redis.rb
+++ b/recipes/redis.rb
@@ -20,7 +20,7 @@
 node.override.redis.config.bind = "0.0.0.0"
 node.override.redis.config.port = node.sensu.redis.port
 
-if node.platform == "ubuntu" && node.platform_version <= "10.04"
+if node.platform == "ubuntu" && node.platform_version <= "12.04"
   node.override.redis.install_type = "source"
 elsif node.platform == "debian"
   node.override.redis.install_type = "source"


### PR DESCRIPTION
Ubuntu 12.04 redis-server is v2.2.12, which doesn't get along well with the Miah's upstream chef-redis cookbook.  Building from source works fine.
