### PR TITLE
Use APT pinning to fix the Sensu version

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -32,6 +32,11 @@ when "debian"
     components node.sensu.use_unstable_repo ? ["unstable"] : ["main"]
     action :add
   end
+
+  apt_preference "sensu" do
+    pin "version #{node.sensu.version}"
+    pin_priority "700"
+  end
 when "rhel"
   include_recipe "yum"
 


### PR DESCRIPTION
This stops version bouncing (and possible related breakage) when the node's
specified Sensu version is lower than the latest version available in the
repository, and the node is upgraded via apt-get
(without pinning, Sensu will be upgraded by APT, then downgraded at next Chef
client run).
