### PR TITLE
Update Gemfile with librarian-chef

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -1,3 +1,3 @@
 source "http://rubygems.org"
 
-gem "librarian"
+gem "librarian-chef"


### PR DESCRIPTION
[As of version 0.1.0](https://github.com/applicationsonline/librarian/blob/master/CHANGELOG.md#010), the librarian gem has split [librarian-chef](http://rubygems.org/gems/librarian-chef) off into it's own gem.
