### PR TITLE
Notify apt-get update as soon as the repository is added

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -31,6 +31,7 @@ when "debian"
     distribution "sensu"
     components node.sensu.use_unstable_repo ? ["unstable"] : ["main"]
     action :add
+    notifies :run, "execute[apt-get update]", :immediately
   end
 
   apt_preference "sensu" do


### PR DESCRIPTION
On some older revisions of the "apt" cookbook, "apt-get update" is not automatically run after adding an APT repository through the LWRP. This PR takes care of that by manually calling apt-get update immediately after adding the repository.
