### PR TITLE
allow setting of keepalive handler

### DIFF
--- a/providers/client.rb
+++ b/providers/client.rb
@@ -1,7 +1,7 @@
 action :create do
   client = Sensu::Helpers.select_attributes(
     new_resource,
-    %w[name address subscriptions]
+    %w[name address keepalive subscriptions]
   ).merge(new_resource.additional)
 
   definition = {

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -3,6 +3,7 @@ actions :create
 attribute :address, :kind_of => String, :required => true
 attribute :subscriptions, :kind_of => Array, :default => Array.new
 attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :keepalive, :kind_of => Hash, :default => Hash.new
 
 def initialize(*args)
   super


### PR DESCRIPTION
adds the keepalive keyword to the client LWRP so you can set a client specific handler for keepalive events.  currently, only the default handler gets tripped when a keepalive event fires.
