### PR TITLE
Add support for check parameters 'refresh' and 'dependencies'; alphabetize attribute lists

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -9,9 +9,10 @@ action :create do
   check = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type command timeout subscribers standalone handle
-      handlers publish low_flap_threshold high_flap_threshold
-      refresh dependencies
+      command dependencies handle handlers 
+      high_flap_threshold low_flap_threshold 
+      publish refresh standalone 
+      subscribers timeout type 
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 

--- a/providers/handler.rb
+++ b/providers/handler.rb
@@ -7,8 +7,8 @@ action :create do
   handler = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type filters mutator severities handlers
-      command timeout socket exchange
+      command exchange filters handlers
+      mutator severities socket timeout type 
     ]
   ).merge(new_resource.additional)
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -1,19 +1,19 @@
 actions :create, :delete
 
-attribute :type, :kind_of => String, :equal_to => %w[status metric]
+attribute :additional, :kind_of => Hash, :default => Hash.new
 attribute :command, :kind_of => String, :required => true
-attribute :timeout, :kind_of => Integer
-attribute :subscribers, :kind_of => Array
-attribute :standalone, :kind_of => [TrueClass, FalseClass]
-attribute :interval, :default => 60
+attribute :dependencies, :kind_of => Array
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array
-attribute :publish, :kind_of => [TrueClass, FalseClass]
-attribute :low_flap_threshold, :kind_of => Integer
 attribute :high_flap_threshold, :kind_of => Integer
+attribute :interval, :default => 60
+attribute :low_flap_threshold, :kind_of => Integer
+attribute :publish, :kind_of => [TrueClass, FalseClass]
 attribute :refresh, :kind_of => Integer
-attribute :dependencies, :kind_of => Array
-attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :standalone, :kind_of => [TrueClass, FalseClass]
+attribute :subscribers, :kind_of => Array
+attribute :timeout, :kind_of => Integer
+attribute :type, :kind_of => String, :equal_to => %w[status metric]
 
 def initialize(*args)
   super

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -1,8 +1,8 @@
 actions :create
 
+attribute :additional, :kind_of => Hash, :default => Hash.new
 attribute :address, :kind_of => String, :required => true
 attribute :subscriptions, :kind_of => Array, :default => Array.new
-attribute :additional, :kind_of => Hash, :default => Hash.new
 
 def initialize(*args)
   super

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -1,7 +1,7 @@
 actions :install, :remove
 
-attribute :version, :kind_of => String
 attribute :options, :kind_of => [String, Hash]
+attribute :version, :kind_of => String
 
 def initialize(*args)
   super

--- a/resources/handler.rb
+++ b/resources/handler.rb
@@ -1,15 +1,15 @@
 actions :create, :delete
 
-attribute :type, :kind_of => String, :equal_to => %w[set pipe tcp udp amqp]
+attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :command, :kind_of => String
+attribute :exchange, :kind_of => Hash
 attribute :filters, :kind_of => Array
+attribute :handlers, :kind_of => Array
 attribute :mutator, :kind_of => String
 attribute :severities, :kind_of => Array
-attribute :handlers, :kind_of => Array
-attribute :command, :kind_of => String
-attribute :timeout, :kind_of => Integer
 attribute :socket, :kind_of => Hash
-attribute :exchange, :kind_of => Hash
-attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :timeout, :kind_of => Integer
+attribute :type, :kind_of => String, :equal_to => %w[set pipe tcp udp amqp]
 
 def initialize(*args)
   super

--- a/resources/json_file.rb
+++ b/resources/json_file.rb
@@ -1,10 +1,10 @@
 actions :create, :delete
 
-attribute :path, :name_attribute => true
-attribute :owner, :kind_of => String, :default => 'root'
+attribute :content, :kind_of => Hash
 attribute :group, :kind_of => String, :default => 'sensu'
 attribute :mode, :kind_of => [String, Integer], :default => 0640
-attribute :content, :kind_of => Hash
+attribute :owner, :kind_of => String, :default => 'root'
+attribute :path, :name_attribute => true
 
 def initialize(*args)
   super


### PR DESCRIPTION
Adds support for 'refresh' and 'dependencies' so they can be used as parameters to `sensu_check` instead of supplying them in the 'additional' hash. 

Also, check, handler, and json_file attribute lists were getting quite large. I alphabetized them so it's easier to see what's included at a glance.
