### PR TITLE
Remove ubuntu-10.04 from test-kitchen platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,10 +10,6 @@ platforms:
   driver_config:
     box: opscode-ubuntu-12.04
     box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box
-- name: ubuntu-10.04
-  driver_config:
-    box: opscode-ubuntu-10.04
-    box_url: https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-10.04_provisionerless.box
 - name: centos-6.4
   driver_config:
     box: opscode-centos-6.4


### PR DESCRIPTION
Per documentation:

Due to the state of flux in Erlang and the Erlang-SSL module, we have
been unable to get RabbitMQ and SSL working on Ubuntu platforms < 11.10
and Debian 6.x.
