### PR TITLE
Require yum cb versions '>= 3.0.0'

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          "0.6.2"
 depends "apt"
 
 # available @ http://community.opscode.com/cookbooks/yum
-depends "yum"
+depends "yum", ">= 3.0.0"
 
 # available @ http://community.opscode.com/cookbooks/windows
 depends "windows", ">= 1.8.8"


### PR DESCRIPTION
#214 introduces a resource method that is not defined for yum versions < 3.0.0

https://github.com/opscode-cookbooks/yum/blame/03e455c4798b2eef918381824ca907e839a1207f/resources/repository.rb#L34
