### PR TITLE
Restrict yum cookbook to 2.4.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ version          "0.8.0"
 depends "apt"
 
 # available @ http://community.opscode.com/cookbooks/yum
-depends "yum"
+depends "yum", "~> 2.4.4"
 
 # available @ http://community.opscode.com/cookbooks/windows
 depends "windows", ">= 1.8.8"


### PR DESCRIPTION
The 3.0.x releases of the community yum cookbook break compatibility with cookbooks that depend on previous functionality per https://github.com/opscode-cookbooks/yum NOTES section. Using 3.0.x yum breaks the gpgcheck being disabled specifically in the sensu repository
