### PR TITLE
expicit permissions for ssl dir - was depending on umask

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,7 +50,11 @@ if node.sensu.use_ssl
   node.override.sensu.rabbitmq.ssl.cert_chain_file = File.join(node.sensu.directory, "ssl", "cert.pem")
   node.override.sensu.rabbitmq.ssl.private_key_file = File.join(node.sensu.directory, "ssl", "key.pem")
 
-  directory File.join(node.sensu.directory, "ssl")
+  directory File.join(node.sensu.directory, "ssl") do
+    owner "root"
+    group "sensu"
+    mode 0750
+  end
 
   ssl = Sensu::Helpers.data_bag_item("ssl")
 


### PR DESCRIPTION
I am getting indeterminate results of the permissions on /etc/sensu/ssl. The directory resource needs to have explicit permissions set in recipes/default.rb.
