### PR TITLE
add amazonlinux support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -27,6 +27,7 @@ depends "redisio", ">= 1.7.0"
   centos
   redhat
   fedora
+  amazon
   windows
 ].each do |os|
   supports os

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -39,11 +39,15 @@ when "debian"
   end
 when "rhel"
   include_recipe "yum"
+  rhel_version_equivalent = node.platform_version
+  if node.platform == "amazon"
+    rhel_version_equivalent = 6
+  end
 
   repo = yum_repository "sensu" do
     description "sensu monitoring"
     repo = node.sensu.use_unstable_repo ? "yum-unstable" : "yum"
-    url "#{node.sensu.yum_repo_url}/#{repo}/el/#{node['platform_version'].to_i}/$basearch/"
+    url "#{node.sensu.yum_repo_url}/#{repo}/el/#{rhel_version_equivalent.to_i}/$basearch/"
     action :add
   end
   repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)


### PR DESCRIPTION
On amazon linux, current platform_version is 2013.03 and the number format of platform_version is different from redhat linux so that this recipe refers to non existent repository url.
