### PR TITLE
Root attrib

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@ default.sensu.use_ssl = true
 default.sensu.use_embedded_ruby = false
 default.sensu.init_style = "sysv"
 default.sensu.service_max_wait = 10
+default.sensu.admin = 'root'
 
 default.sensu.apt_repo_url = "http://repos.sensuapp.org/apt"
 default.sensu.yum_repo_url = "http://repos.sensuapp.org"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,15 @@ end
 
 case node.platform
 when "windows"
+  group "sensu" do
+    action :create
+    gid 1001
+  end
+
+  user "sensu" do
+    action :create
+    gid 1001
+  end
   include_recipe "sensu::_windows"
 else
   include_recipe "sensu::_linux"
@@ -37,9 +46,9 @@ directory node.sensu.log_directory do
   recursive true
   mode 0750
 end
-  
+
 directory File.join(node.sensu.directory, "conf.d") do
-  owner "root"
+  owner "sensu"
   group "sensu"
   recursive true
   mode 0750
@@ -51,7 +60,7 @@ if node.sensu.use_ssl
   node.override.sensu.rabbitmq.ssl.private_key_file = File.join(node.sensu.directory, "ssl", "key.pem")
 
   directory File.join(node.sensu.directory, "ssl") do
-    owner "root"
+    owner node['sensu']['admin']
     group "sensu"
     mode 0750
   end
@@ -60,14 +69,14 @@ if node.sensu.use_ssl
 
   file node.sensu.rabbitmq.ssl.cert_chain_file do
     content ssl["client"]["cert"]
-    owner "root"
+    owner node['sensu']['admin']
     group "sensu"
     mode 0640
   end
 
   file node.sensu.rabbitmq.ssl.private_key_file do
     content ssl["client"]["key"]
-    owner "root"
+    owner node['sensu']['admin']
     group "sensu"
     mode 0640
   end


### PR DESCRIPTION
Current cookbook is incompatible with Windows because in many templates it sets the root user as owner but that user does not exist in Windows. I introduced this attribute to use root user as default:

default.sensu.admin = 'root'

but if you want to use Windows you can just change that attribute to 'administrator'. The cookbook is tested on the Server and on Linux and Windows clients.
