### PR TITLE
"rhel" not need [include_recipe "yum"]

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -38,8 +38,6 @@ when "debian"
     pin_priority "700"
   end
 when "rhel"
-  include_recipe "yum"
-
   repo = yum_repository "sensu" do
     description "sensu monitoring"
     repo = node.sensu.use_unstable_repo ? "yum-unstable" : "yum"


### PR DESCRIPTION
Hello.

need to `include_recipe "yum"` on rhel?
This seems to be unnecessary as far as I tested.
Please check this.

Thank you.
