### PR TITLE
check for rabbitmq host to prevent headache when its not provided

### DIFF
--- a/recipes/client_service.rb
+++ b/recipes/client_service.rb
@@ -17,6 +17,10 @@
 # limitations under the License.
 #
 
+if !node[:sensu].attribute?(:rabbitmq) or !node[:sensu][:rabbitmq].attribute?(:host)
+    Chef::Application.fatal!("RabbitMQ Host not provided, service will error out on start.  Please provide a node[:rabbitmq][:host]")
+end
+
 sensu_service "sensu-client" do
   init_style node.sensu.init_style
   action [:enable, :start]


### PR DESCRIPTION
Just a simple check in the client_service recipe.  If you are deploying a client and do not have a rabbitmq host the service fails to start.  This fails your chef run and the errors bubbled back up to chef aren't helpful for debugging the issue.

This will enforce providing a rabbitmq host and clearly let you know when you do not so you don't chase your tail figuring out why your service isn't starting.
