### PR TITLE
Add 'refresh' attribute to check lwrp

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -10,7 +10,7 @@ action :create do
     new_resource,
     %w[
       type command timeout subscribers standalone aggregate handle
-      handlers publish low_flap_threshold high_flap_threshold
+      handlers publish low_flap_threshold high_flap_threshold refresh
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -13,6 +13,7 @@ attribute :publish, :kind_of => [TrueClass, FalseClass]
 attribute :low_flap_threshold, :kind_of => Integer
 attribute :high_flap_threshold, :kind_of => Integer
 attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :refresh, :kind_of => Integer
 
 def initialize(*args)
   super


### PR DESCRIPTION
current cookbook no have 'refresh' attribute at sensu_check lwrp.
so I add 'refresh' attribute to available configure the sensu check.

sensu_check check['name'] do
  ...
  interval check['interval']
  refresh check['refresh']  << add
end
