### PR TITLE
change use_embedded_ruby = false to use_embedded_ruby = true

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,7 +14,7 @@ default.sensu.version = "0.12.6-4"
 default.sensu.use_unstable_repo = false
 default.sensu.log_level = "info"
 default.sensu.use_ssl = true
-default.sensu.use_embedded_ruby = false
+default.sensu.use_embedded_ruby = true
 default.sensu.init_style = "sysv"
 default.sensu.service_max_wait = 10
 


### PR DESCRIPTION
Hi!

I think "true" is better than "false".
Embedded ruby and some useful gems(like sensu-plugin) are installed together by using sensu-chef.

If you agree, please merge pull request.

Hiroaki.
