### PR TITLE
Make sensu services more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Sensu services, "sysv" and "runit" are currently supported.
 `node.sensu.service_max_wait` - How long service scripts should wait
 for Sensu to start/stop.
 
+`node.sensu.init_env_settings` - {'ENVNAME' => '/env/value'}.
+Export each environment variable specified in the provided hash.
+Unset any variable set to `nil`. If `use_embedded_ruby` is specified
+defaults to unsetting any Ruby related environment variable so
+that the services can be restarted even if `chef-solo` is executed
+with rbenv or RVM.
+
 ### RabbitMQ
 
 `node.sensu.rabbitmq.host` - RabbitMQ host.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,7 @@ else
   default.sensu.admin_user = "root"
   default.sensu.directory = "/etc/sensu"
   default.sensu.log_directory = "/var/log/sensu"
+  default.sensu.init_env_settings = nil
 end
 
 # installation

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -81,6 +81,7 @@ if node.sensu.use_embedded_ruby
     'RUBYLIB' => nil,
     'RUBYOPT' => nil,
     'GEM_HOME' => nil,
+    'GEM_PATH' => nil,
     'BUNDLE_BIN_PATH' => nil,
     'BUNDLE_GEMFILE' => nil,
   }

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -76,7 +76,22 @@ package "sensu" do
   notifies :create, "ruby_block[sensu_service_trigger]"
 end
 
+if node.sensu.use_embedded_ruby
+  init_env_settings = node.sensu.init_env_settings || {
+    'RUBYLIB' => nil,
+    'RUBYOPT' => nil,
+    'GEM_HOME' => nil,
+    'BUNDLE_BIN_PATH' => nil,
+    'BUNDLE_GEMFILE' => nil,
+  }
+else
+  init_env_settings = node.sensu.init_env_settings || {}
+end
 template "/etc/default/sensu" do
   source "sensu.default.erb"
+  variables(
+    :export_env => init_env_settings.reject{|k, v| v.nil? },
+    :unset_env => init_env_settings.select{|k, v| v.nil? }.keys,
+  )
   notifies :create, "ruby_block[sensu_service_trigger]"
 end

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -91,7 +91,7 @@ end
 template "/etc/default/sensu" do
   source "sensu.default.erb"
   variables(
-    :export_env => init_env_settings.reject{|k, v| v.nil? },
+    :set_env => init_env_settings.reject{|k, v| v.nil? },
     :unset_env => init_env_settings.select{|k, v| v.nil? }.keys,
   )
   notifies :create, "ruby_block[sensu_service_trigger]"

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -4,6 +4,6 @@ LOG_LEVEL=<%= node.sensu.log_level %>
 SERVICE_MAX_WAIT=<%= node.sensu.service_max_wait %>
 
 unset <%= @unset_env.join ' ' %>
-<% @export_env.each do |env, value| %>
-export <%= env %>=<%= value %>
+<% @set_env.each do |env, value| %>
+<%= env %>=<%= value %>
 <% end %>

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -3,5 +3,7 @@ LOG_DIR=<%= node.sensu.log_directory %>
 LOG_LEVEL=<%= node.sensu.log_level %>
 SERVICE_MAX_WAIT=<%= node.sensu.service_max_wait %>
 
-# Avoid issues when chef-solo is run with rbenv for instance:
-unset RUBYLIB RUBYOPT GEM_HOME BUNDLE_BIN_PATH BUNDLE_GEMFILE
+unset <%= @unset_env.join ' ' %>
+<% @export_env.each do |env, value| %>
+export <%= env %>=<%= value %>
+<% end %>

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -2,3 +2,6 @@ EMBEDDED_RUBY=<%= node.sensu.use_embedded_ruby %>
 LOG_DIR=<%= node.sensu.log_directory %>
 LOG_LEVEL=<%= node.sensu.log_level %>
 SERVICE_MAX_WAIT=<%= node.sensu.service_max_wait %>
+
+# Avoid issues when chef-solo is run with rbenv for instance:
+unset RUBYLIB RUBYOPT GEM_HOME BUNDLE_BIN_PATH BUNDLE_GEMFILE


### PR DESCRIPTION
Without this change I get this error in my server:

```
---- Begin output of /etc/init.d/sensu-dashboard restart ----
STDOUT: * Stopping sensu-dashboard
   ...fail!
 * Starting sensu-dashboard
   ...fail!
STDERR: /var/lib/gems/1.9.1/gems/bundler-1.5.1/lib/bundler/rubygems_integration.rb:240:in `block in replace_gem': sensu-dashboard is not part of the bundle. Add it to Gemfile. (Gem::LoadError)
        from /opt/sensu/bin/sensu-dashboard:22:in `<main>'
---- End output of /etc/init.d/sensu-dashboard restart ----
```