### PR TITLE
Support Chef::DelayedEvaluator (lazy) in JSON

### DIFF
--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -12,6 +12,9 @@ module Sensu
       def sanitize(raw_hash)
         sanitized = Hash.new
         raw_hash.each do |key, value|
+          # Expand Chef::DelayedEvaluator (lazy)
+          value = value.call if value.respond_to?(:call)
+
           case value
           when Hash
             sanitized[key] = sanitize(value) unless value.empty?


### PR DESCRIPTION
This is probably the wrong way to do it, but this adds support for `Chef::DelayedEvaluator` values (`lazy`) in JSON values like subscriptions.
