### PR TITLE
Update yum to 3.0.0 in examples/Cheffile to avoid infinite loop in librarian-chef

### DIFF
--- a/examples/Cheffile
+++ b/examples/Cheffile
@@ -1,7 +1,7 @@
 site 'http://community.opscode.com/api/v1'
 
 cookbook "apt", "2.1.1"
-cookbook "yum", "2.3.0"
+cookbook "yum", "3.0.0"
 cookbook "rabbitmq", "2.3.0"
 
 cookbook "redis",


### PR DESCRIPTION
Yum 2.3.0 was causing issues with the sudo and uchiwa repo's referred, causing librarian-chef to go into infinite loop. Updating to 3.0.0 solves this issue.
