### PR TITLE
Add node.sensu.{user,group} attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Enables and starts the Sensu API.
 
 `node.sensu.use_ssl` - If Sensu and RabbitMQ are to use SSL.
 
+`node.sensu.user` - The user who owns all sensu files and directories. Default
+"sensu".
+
+`node.sensu.group` - The group that owns all sensu files and directories.
+Default "sensu".
+
 `node.sensu.use_embedded_ruby` - If Sensu Ruby handlers and plugins
 use the embedded Ruby in the Sensu package.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,6 +7,8 @@ if platform_family?("windows")
   default.sensu.windows.package_options = nil
 else
   default.sensu.admin_user = "root"
+  default.sensu.user = "sensu"
+  default.sensu.group = "sensu"
   default.sensu.directory = "/etc/sensu"
   default.sensu.log_directory = "/var/log/sensu"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,8 +31,8 @@ else
 end
 
 directory node.sensu.log_directory do
-  owner "sensu"
-  group "sensu"
+  owner node.sensu.user
+  group node.sensu.group
   recursive true
   mode 0750
 end
@@ -45,7 +45,7 @@ end
 ].each do |dir|
   directory File.join(node.sensu.directory, dir) do
     owner node.sensu.admin_user
-    group "sensu"
+    group node.sensu.group
     recursive true
     mode 0750
   end
@@ -58,7 +58,7 @@ if node.sensu.use_ssl
 
   directory File.join(node.sensu.directory, "ssl") do
     owner node.sensu.admin_user
-    group "sensu"
+    group node.sensu.group
     mode 0750
   end
 
@@ -67,14 +67,14 @@ if node.sensu.use_ssl
   file node.sensu.rabbitmq.ssl.cert_chain_file do
     content ssl["client"]["cert"]
     owner node.sensu.admin_user
-    group "sensu"
+    group node.sensu.group
     mode 0640
   end
 
   file node.sensu.rabbitmq.ssl.private_key_file do
     content ssl["client"]["key"]
     owner node.sensu.admin_user
-    group "sensu"
+    group node.sensu.group
     mode 0640
   end
 else


### PR DESCRIPTION
This way people can change the owning groups for logs and such to
conform to their access policies.
