### PR TITLE
allow downgrade on package so sensu can managed the version that is installed

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -63,12 +63,19 @@ else
   end
   repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
 end
-
-package "sensu" do
-  version node.sensu.version
-  options package_options
-  allow_downgrade true
-  notifies :create, "ruby_block[sensu_service_trigger]"
+if platform_family == 'debian'
+  package "sensu" do
+    version node.sensu.version
+    options package_options
+    notifies :create, "ruby_block[sensu_service_trigger]"
+  end
+else
+  yum_package "sensu" do
+    version node.sensu.version
+    options package_options
+    allow_downgrade true
+    notifies :create, "ruby_block[sensu_service_trigger]"
+  end
 end
 
 template "/etc/default/sensu" do


### PR DESCRIPTION
allow downgrade on package so sensu can managed the version that is installed

if a newer version gets installed e.g. someone does yum update and chef-client then tries to run, it will fail as allow downgrade was not specified.
