### PR TITLE
Add ignore_failure attribute to service resource definitions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ default.sensu.use_ssl = true
 default.sensu.use_embedded_ruby = false
 default.sensu.init_style = "sysv"
 default.sensu.service_max_wait = 10
+default.sensu.ignore_start_failure = false
 
 default.sensu.apt_repo_url = "http://repos.sensuapp.org/apt"
 default.sensu.yum_repo_url = "http://repos.sensuapp.org"

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -44,6 +44,7 @@ def load_current_resource
       Chef::Provider::Service::Init::Redhat
     end
     service new_resource.service do
+      ignore_failure node.sensu.ignore_start_failure
       provider service_provider
       supports :status => true, :restart => true
       retries 3
@@ -53,6 +54,7 @@ def load_current_resource
     end
   when "runit"
     service new_resource.service do
+      ignore_failure node.sensu.ignore_start_failure
       start_command "#{sensu_ctl} #{new_resource.service} start"
       stop_command "#{sensu_ctl} #{new_resource.service} stop"
       status_command "#{sensu_ctl} #{new_resource.service} status"

--- a/recipes/client_service.rb
+++ b/recipes/client_service.rb
@@ -18,6 +18,7 @@
 #
 
 sensu_service "sensu-client" do
+  ignore_failure node.sensu.ignore_start_failure
   init_style node.sensu.init_style
   action [:enable, :start]
 end

--- a/recipes/server_service.rb
+++ b/recipes/server_service.rb
@@ -18,6 +18,7 @@
 #
 
 sensu_service "sensu-server" do
+  ignore_failure node.sensu.ignore_start_failure
   init_style node.sensu.init_style
   action [:enable, :start]
 end

--- a/test/integration/asset/serverspec/asset_spec.rb
+++ b/test/integration/asset/serverspec/asset_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 

--- a/test/integration/encrypted/serverspec/dependency_spec.rb
+++ b/test/integration/encrypted/serverspec/dependency_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 
@@ -17,7 +16,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +24,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/encrypted/serverspec/encrypted_spec.rb
+++ b/test/integration/encrypted/serverspec/encrypted_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 

--- a/test/integration/runit/serverspec/dependency_spec.rb
+++ b/test/integration/runit/serverspec/dependency_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 
@@ -17,7 +16,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +24,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/runit/serverspec/runit_restart_spec.rb
+++ b/test/integration/runit/serverspec/runit_restart_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 
@@ -20,13 +19,13 @@ describe file(pid_file) do
 end
 
 describe command("cp #{pid_file} /tmp/_pid_file") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command("/opt/sensu/bin/sensu-ctl #{service} restart") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command("diff #{pid_file} /tmp/_pid_file") do
-  it { should return_exit_status 1 }
+  its(:exit_status) { should eq 1 }
 end

--- a/test/integration/runit/serverspec/runit_spec.rb
+++ b/test/integration/runit/serverspec/runit_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 

--- a/test/integration/sysv/serverspec/dependency_spec.rb
+++ b/test/integration/sysv/serverspec/dependency_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 
@@ -17,7 +16,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +24,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/sysv/serverspec/sysv_spec.rb
+++ b/test/integration/sysv/serverspec/sysv_spec.rb
@@ -2,12 +2,11 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
+set :backend, :exec
 
 RSpec.configure do |c|
   c.before :all do
-    c.path = "/sbin:/usr/sbin"
+    c.path = "/bin:/sbin:/usr/sbin:/usr/bin"
   end
 end
 


### PR DESCRIPTION
Fixes issue #296.

Additionally, I've done the work to make the serverspec tests compatible with the serverspec 2 release earlier this month.