### PR TITLE
rabbitmq: Run rabbitmq cookbook after rabbitmq attributes are modified

### DIFF
--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -17,9 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe "rabbitmq"
-include_recipe "rabbitmq::mgmt_console"
-
 if node.sensu.use_ssl
   node.override.rabbitmq.ssl = true
   node.override.rabbitmq.ssl_port = node.sensu.rabbitmq.port
@@ -46,6 +43,9 @@ if node.sensu.use_ssl
     node.override.rabbitmq["ssl_#{item}"] = path
   end
 end
+
+include_recipe "rabbitmq"
+include_recipe "rabbitmq::mgmt_console"
 
 service "restart #{node.rabbitmq.service_name}" do
   service_name node.rabbitmq.service_name


### PR DESCRIPTION
If I understand the rabbitmq recipe correctly, the `if node.sensu.use_ssl ...` block is completely ignored by the precedent `include_recipe "rabbitmq"`. It makes `ssl_cacert`, `ssl_cert` and `ssl_key` in `/etc/rabbitmq/rabbitmq.config` to be the unreasonable default like `/path/to/cacert.pem`.

This patch moves the `include_recipe`s after the `if` block so that `rabbitmq` cookbook can use the overridden attributes.
