### PR TITLE
Allow for override of data bag items from another source

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Sensu services, "sysv" and "runit" are currently supported.
 `node.sensu.service_max_wait` - How long service scripts should wait
 for Sensu to start/stop.
 
+`node.sensu.data_bag_items` - Allows override of the data bag processing
+performed by the sensu-chef cookbook. For example the content of the 
+"sensu" data bag item named "config" will be overridden by a Hash stored 
+under node.sensu.data_bag_items.config.
+
 ### RabbitMQ
 
 `node.sensu.rabbitmq.host` - RabbitMQ host.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,8 @@ default.sensu.apt_repo_url = "http://repos.sensuapp.org/apt"
 default.sensu.yum_repo_url = "http://repos.sensuapp.org"
 default.sensu.msi_repo_url = "http://repos.sensuapp.org/msi"
 
+default.sensu.data_bag_items = {}
+
 # rabbitmq
 default.sensu.rabbitmq.host = "localhost"
 default.sensu.rabbitmq.port = 5671

--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -36,7 +36,7 @@ module Sensu
       end
 
       def data_bag_item(item, missing_ok=false)
-        raw_hash = node.sensu.data_bag_items.item || Chef::DataBagItem.load("sensu", item)
+        raw_hash = node.sensu.data_bag_items[item] || Chef::DataBagItem.load("sensu", item)
         encrypted = raw_hash.detect do |key, value|
           if value.is_a?(Hash)
             value.has_key?("encrypted_data")

--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -36,7 +36,7 @@ module Sensu
       end
 
       def data_bag_item(item, missing_ok=false)
-        raw_hash = Chef::DataBagItem.load("sensu", item)
+        raw_hash = node.sensu.data_bag_items.item || Chef::DataBagItem.load("sensu", item)
         encrypted = raw_hash.detect do |key, value|
           if value.is_a?(Hash)
             value.has_key?("encrypted_data")


### PR DESCRIPTION
#306 
This provides a way to override sensu data bag items. This permits the flexibility to read an alternate data bag or substitute different data on an environment by environment basis.