### PR TITLE
Stash api fix, added expire option

### DIFF
--- a/definitions/silence_check.rb
+++ b/definitions/silence_check.rb
@@ -1,4 +1,4 @@
-define :sensu_silence_check, :action => :create, :expire => -1, :payload => {} do
+define :sensu_silence_check, :action => :create, :expire => nil, :payload => {} do
 
   if params[:client].nil?
     params[:client] = node.name

--- a/definitions/silence_check.rb
+++ b/definitions/silence_check.rb
@@ -1,17 +1,14 @@
-define :sensu_silence_check, :action => :create, :payload => {} do
+define :sensu_silence_check, :action => :create, :expire => -1, :payload => {} do
 
   if params[:client].nil?
     params[:client] = node.name
   end
 
   if params[:action] == :create or params[:action] == :silence
-    # add a timestamp and owner to the payload
-    # when we look at the stash later, these bits helps us know how old a stash is and how it got there
-    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'owner' => 'chef'})
-
     sensu_api_stash "silence/#{params[:client]}/#{params[:name]}" do
       api_uri params[:api_uri]
-      payload merged_payload
+      expire params[:expire]
+      payload params[:payload]
       action :create
     end
   end

--- a/definitions/silence_client.rb
+++ b/definitions/silence_client.rb
@@ -1,4 +1,4 @@
-define :sensu_silence_client, :action => :create, :expire => -1, :payload => {} do
+define :sensu_silence_client, :action => :create, :expire => nil, :payload => {} do
   if params[:action] == :create or params[:action] == :silence
     sensu_api_stash "silence/#{params[:name]}" do
       api_uri params[:api_uri]

--- a/definitions/silence_client.rb
+++ b/definitions/silence_client.rb
@@ -1,12 +1,9 @@
-define :sensu_silence_client, :action => :create, :payload => {} do
+define :sensu_silence_client, :action => :create, :expire => -1, :payload => {} do
   if params[:action] == :create or params[:action] == :silence
-    # add a timestamp and owner to the payload
-    # when we look at the stash later, these bits helps us know how old a stash is and how it got there
-    merged_payload = params[:payload].merge({'timestamp' => Time.now.to_i, 'owner' => 'chef'})
-
     sensu_api_stash "silence/#{params[:name]}" do
       api_uri params[:api_uri]
-      payload merged_payload
+      expire params[:expire]
+      payload params[:payload]
       action :create
     end
   end

--- a/providers/api_stash.rb
+++ b/providers/api_stash.rb
@@ -8,7 +8,12 @@ end
 action :create do
   api = Sensu::API::Stash.new(new_resource.api_uri)
   unless new_resource.payload == @current_resource.payload
-    if api.post("/stashes/#{new_resource.name}", new_resource.payload)
+    # add path, timestamp and owner to the payload
+    # when we look at the stash later, these bits helps us know how old a stash is and how it got there
+    # allow to overwrite payload completely
+    payload = {'path' => new_resource.name, 'expire' => new_resource.expire, 'content' => { 'timestamp' => Time.now.to_i, 'owner' => 'chef'}}
+    merged_payload = payload.merge(new_resource.payload)
+    if api.post("/stashes", merged_payload)
       new_resource.updated_by_last_action(true)
     end
   end

--- a/providers/api_stash.rb
+++ b/providers/api_stash.rb
@@ -11,7 +11,12 @@ action :create do
     # add path, timestamp and owner to the payload
     # when we look at the stash later, these bits helps us know how old a stash is and how it got there
     # allow to overwrite payload completely
-    payload = {'path' => new_resource.name, 'expire' => new_resource.expire, 'content' => { 'timestamp' => Time.now.to_i, 'owner' => 'chef'}}
+    payload = {'path' => new_resource.name, 'content' => { 'timestamp' => Time.now.to_i, 'owner' => 'chef'}}
+
+    if new_resource.expire != nil
+      payload['expire'] = new_resource.expire
+    end
+
     merged_payload = payload.merge(new_resource.payload)
     if api.post("/stashes", merged_payload)
       new_resource.updated_by_last_action(true)

--- a/resources/api_stash.rb
+++ b/resources/api_stash.rb
@@ -2,6 +2,7 @@ actions :create, :delete
 
 attribute :api_uri, :kind_of => String, :required => true
 attribute :payload, :kind_of => [Hash, FalseClass], :default => Hash.new
+attribute :expire, :kind_of => Integer, :default => -1
 
 def initialize(*args)
   super

--- a/resources/api_stash.rb
+++ b/resources/api_stash.rb
@@ -2,7 +2,7 @@ actions :create, :delete
 
 attribute :api_uri, :kind_of => String, :required => true
 attribute :payload, :kind_of => [Hash, FalseClass], :default => Hash.new
-attribute :expire, :kind_of => Integer, :default => -1
+attribute :expire, :kind_of => Integer, :default => nil
 
 def initialize(*args)
   super


### PR DESCRIPTION
Sensu api only allows expire parameter (version 0.12 and up) when calling '/stashes' endpoint
http://sensuapp.org/docs/0.12/api-stashes

This PR changes creates payload with path and expire params created by default. Default expiry time is never.
Payload can be overwitten by supplying an alternative hash. The merge order for payload also allows to decouple the resource name from 'path' variable, so you can have sensu_stash_api resources with unique names but common path:
```
sensu_stash_api 'stash_node' do
   api_uri "http://****"
   payload {"path" => "silence/node1.local"}
   expire 10
end
```


