### PR TITLE
Update serverspec tests & fix rabbitmq ssl in ubuntu 12.04

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,20 +6,23 @@ description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "2.3.0"
 
-# available @ http://community.opscode.com/cookbooks/apt
+# available @ http://supermarket.chef.io/cookbooks/apt
 depends "apt"
 
-# available @ http://community.opscode.com/cookbooks/yum
+# available @ http://supermarket.chef.io/cookbooks/yum
 depends "yum"
 
-# available @ http://community.opscode.com/cookbooks/windows
+# available @ http://supermarket.chef.io/cookbooks/windows
 depends "windows", ">= 1.8.8"
 
-# available @ http://community.opscode.com/cookbooks/rabbitmq
+# available @ http://supermarket.chef.io/cookbooks/rabbitmq
 depends "rabbitmq", ">= 2.0.0"
 
-# available @ http://community.opscode.com/cookbooks/redisio
+# available @ http://supermarket.chef.io/cookbooks/redisio
 depends "redisio", ">= 1.7.0"
+
+# available @ https://supermarket.chef.io/cookbooks/chef-sugar
+depends "chef-sugar"
 
 %w[
   ubuntu

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+include_recipe "chef-sugar"
+
 group "rabbitmq"
 
 if node.sensu.use_ssl
@@ -45,6 +47,10 @@ if node.sensu.use_ssl
     node.override.rabbitmq["ssl_#{item}"] = path
   end
 end
+
+# The packaged erlang in 12.04 (and below) is vulnerable to 
+# the poodly exploit which stops rabbitmq starting its SSL listener
+node.override.erlang.install_method = 'esl' if ubuntu_before_trusty?
 
 include_recipe "rabbitmq"
 include_recipe "rabbitmq::mgmt_console"

--- a/test/integration/asset/serverspec/asset_spec.rb
+++ b/test/integration/asset/serverspec/asset_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 %w[
   check-http.rb

--- a/test/integration/encrypted/serverspec/dependency_spec.rb
+++ b/test/integration/encrypted/serverspec/dependency_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe file("/opt/sensu/embedded/bin/ruby") do
   it { should be_file }
@@ -17,7 +11,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +19,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/encrypted/serverspec/encrypted_spec.rb
+++ b/test/integration/encrypted/serverspec/encrypted_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe service("sensu-server") do
   it { should be_enabled }

--- a/test/integration/runit/serverspec/dependency_spec.rb
+++ b/test/integration/runit/serverspec/dependency_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe file("/opt/sensu/embedded/bin/ruby") do
   it { should be_file }
@@ -17,7 +11,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +19,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/runit/serverspec/runit_restart_spec.rb
+++ b/test/integration/runit/serverspec/runit_restart_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 service = "sensu-client"
 
@@ -20,13 +14,13 @@ describe file(pid_file) do
 end
 
 describe command("cp #{pid_file} /tmp/_pid_file") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command("/opt/sensu/bin/sensu-ctl #{service} restart") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe command("diff #{pid_file} /tmp/_pid_file") do
-  it { should return_exit_status 1 }
+  its(:exit_status) { should eq 1 }
 end

--- a/test/integration/runit/serverspec/runit_spec.rb
+++ b/test/integration/runit/serverspec/runit_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe file("/opt/sensu/sv/sensu-server/supervise/pid") do
   its(:content) { should match /^[0-9]+$/ }

--- a/test/integration/sysv/serverspec/dependency_spec.rb
+++ b/test/integration/sysv/serverspec/dependency_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe file("/opt/sensu/embedded/bin/ruby") do
   it { should be_file }
@@ -17,7 +11,7 @@ describe file("/opt/sensu/embedded/bin/ruby") do
 end
 
 describe command("ps aux | grep rabbitmq-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(5671) do
@@ -25,7 +19,7 @@ describe port(5671) do
 end
 
 describe command("ps aux | grep redis-server | grep -v grep") do
-  it { should return_exit_status 0 }
+  its(:exit_status) { should eq 0 }
 end
 
 describe port(6379) do

--- a/test/integration/sysv/serverspec/sysv_spec.rb
+++ b/test/integration/sysv/serverspec/sysv_spec.rb
@@ -2,14 +2,8 @@ require "serverspec"
 require "net/http"
 require "uri"
 
-include Serverspec::Helper::Exec
-include Serverspec::Helper::DetectOS
-
-RSpec.configure do |c|
-  c.before :all do
-    c.path = "/sbin:/usr/sbin"
-  end
-end
+set :backend, :exec
+set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
 
 describe service("sensu-server") do
   it { should be_enabled }


### PR DESCRIPTION
This updates all the serverspec tests to v2 syntax.

Once updated it became clear that the 12.04 tests were failing. This was because the 12.04 erlang is vulnerable to the poodle exploit which causes rabbitmq to disable its SSL listener. For that reason I have set versions of ubuntu prior to trusty to use the ESL erlang packages which appear to work. In order to achieve that I have included `chef-sugar` so that I could use the `ubuntu_before_trusty?` conditional.

Also fixed the URLs in the metadata to point to chef supermarket not the old community site.