### PR TITLE
Make the Sensu directory's mode configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,7 @@ else
   default.sensu.user = "sensu"
   default.sensu.group = "sensu"
   default.sensu.directory = "/etc/sensu"
+  default.sensu.directory_mode = "0750"
   default.sensu.log_directory = "/var/log/sensu"
   default.sensu.log_directory_mode = "0750"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ end
     owner node.sensu.admin_user
     group node.sensu.group
     recursive true
-    mode 0750
+    mode node.sensu.directory_mode
   end
 end
 


### PR DESCRIPTION
Sometimes you want to be more or less secure. 

Especially when the Uchiwa dpkg needs read access as "uchiwa" to /etc/sensu.