### PR TITLE
Allows for random_password to ensure requirements

### DIFF
--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -58,10 +58,38 @@ module Sensu
         missing_ok ? nil : raise(error)
       end
 
-      def random_password(length=20)
+      def random_password(length=20, number=false, upper=false, lower=false, special=false)
         password = ""
-        while password.length < length
-          password << ::OpenSSL::Random.random_bytes(1).gsub(/\W/, '')
+        requiredOffset = 0
+        requiredOffset += 1 if number
+        requiredOffset += 1 if upper
+        requiredOffset += 1 if lower
+        requiredOffset += 1 if special
+        length = requiredOffset if length < requiredOffset
+        limit = password.length < (length - requiredOffset)
+
+        while limit || requiredOffset > 0
+          push = false
+          c = ::OpenSSL::Random.random_bytes(1).gsub(/\W/, '')
+          if c != ""
+            if c =~ /[[:digit:]]/
+              requiredOffset -= 1 if number
+              number = false
+            elsif c >= 'a' && c <= 'z'
+              requiredOffset -= 1 if lower
+              lower = false
+            elsif c >= 'A' && c <= 'Z'
+              requiredOffset -= 1 if upper
+              upper = false
+            else
+              requiredOffset -= 1 if special
+              special = false
+            end
+          end
+          limit = password.length < (length - requiredOffset)
+          if limit
+            password << c
+          end
         end
         password
       end

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -20,7 +20,7 @@
 Chef::Recipe.send(:include, Windows::Helper)
 
 user "sensu" do
-  password Sensu::Helpers.random_password
+  password Sensu::Helpers.random_password(20, true, true, true, true)
   not_if {
     user = Chef::Util::Windows::NetUser.new("sensu")
     !!user.get_info rescue false


### PR DESCRIPTION
Updated random_password function to ensure certain level of complexity is met due to occasional issues with windows server. It will act as it currently does by default. 

Also updated the _windows.rb to ensure password requirements for windows servers as sensu will occasionally fail when creating the user on windows server 2012

fixes #249