### PR TITLE
Fix chef-vault integration in Sensu::Helpers

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -2,3 +2,4 @@ site "http://community.opscode.com/api/v1"
 
 cookbook "sensu", path: "."
 cookbook "sensu-test", path: "test/cookbooks/sensu-test"
+cookbook "chef-vault", git: "https://github.com/opscode-cookbooks/chef-vault", ref: "master"

--- a/Cheffile
+++ b/Cheffile
@@ -2,4 +2,3 @@ site "http://community.opscode.com/api/v1"
 
 cookbook "sensu", path: "."
 cookbook "sensu-test", path: "test/cookbooks/sensu-test"
-cookbook "chef-vault", git: "https://github.com/opscode-cookbooks/chef-vault", ref: "master"

--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -2,6 +2,7 @@ require "openssl"
 
 module Sensu
   class Helpers
+    extend ChefVaultItem
     class << self
       def select_attributes(attributes, keys)
         attributes.to_hash.reject do |key, value|

--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -2,7 +2,7 @@ require "openssl"
 
 module Sensu
   class Helpers
-    extend ChefVaultItem
+    extend ChefVaultItem if Kernel.const_defined?("ChefVaultItem")
     class << self
       def select_attributes(attributes, keys)
         attributes.to_hash.reject do |key, value|

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "rabbitmq", ">= 2.0.0"
 depends "redisio", ">= 1.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
-suggests "chef-vault", ">= 1.1.5"
+depends "chef-vault", ">= 1.1.5"
 
 %w[
   ubuntu

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "rabbitmq", ">= 2.0.0"
 depends "redisio", ">= 1.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
-depends "chef-vault", ">= 1.1.5"
+depends "chef-vault", ">= 1.2.0"
 
 %w[
   ubuntu

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "rabbitmq", ">= 2.0.0"
 depends "redisio", ">= 1.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
-depends "chef-vault", ">= 1.2.0"
+suggests "chef-vault", ">= 1.2.0"
 
 %w[
   ubuntu

--- a/test/cookbooks/sensu-test/metadata.rb
+++ b/test/cookbooks/sensu-test/metadata.rb
@@ -8,3 +8,4 @@ version          '0.1.0'
 
 depends          'logrotate'
 depends          'sensu'
+depends          'chef-vault'

--- a/test/cookbooks/sensu-test/recipes/default.rb
+++ b/test/cookbooks/sensu-test/recipes/default.rb
@@ -19,6 +19,8 @@
 
 include_recipe "logrotate"
 
+include_recipe "chef-vault"
+
 include_recipe "sensu::default"
 
 sensu_client node.name do

--- a/test/integration/vault/data_bags/sensu/config.json
+++ b/test/integration/vault/data_bags/sensu/config.json
@@ -1,6 +1,7 @@
 {
   "id": "config",
   "rabbitmq": {
+    "encrypted_data": "",
     "password": "vaultpassword"
   }
 }

--- a/test/integration/vault/data_bags/sensu/config_keys.json
+++ b/test/integration/vault/data_bags/sensu/config_keys.json
@@ -1,0 +1,3 @@
+{
+  "id": "config_keys"
+}


### PR DESCRIPTION
I hit this bug in production and it's a sneaky one. This test case forces the [encrypted guard](https://github.com/sensu/sensu-chef/blob/81e88fdaedc3926fb9eb0416fc40992464021cdd/libraries/sensu_helpers.rb#L40-L45) to actually call the chef_vault_item method as it was being bypassed before. So now the new issue I cannot resolve is, how to include the other chef-vault module and get this passing.

Here is the backtrace you get:

```
================================================================================
Recipe Compile Error in /tmp/kitchen/cache/cookbooks/sensu-test/recipes/default.rb
================================================================================

       NoMethodError
       -------------
       undefined method `chef_vault_item' for Sensu::Helpers:Class

       Cookbook Trace:
       ---------------
         /tmp/kitchen/cache/cookbooks/sensu/libraries/sensu_helpers.rb:47:in `data_bag_item'
         /tmp/kitchen/cache/cookbooks/sensu/recipes/rabbitmq.rb:82:in `from_file'
         /tmp/kitchen/cache/cookbooks/sensu-test/recipes/default.rb:35:in `from_file'

       Relevant File Content:
       ----------------------
       /tmp/kitchen/cache/cookbooks/sensu/libraries/sensu_helpers.rb:

        40:          encrypted = raw_hash.detect do |key, value|
        41:            if value.is_a?(Hash)
        42:              value.has_key?("encrypted_data")
        43:            end
        44:          end
        45:          if encrypted
        46:            if Chef::DataBag.load("sensu").key? "#{item}_keys"
        47>>             chef_vault_item("sensu", item)
        48:            else
        49:              secret = Chef::EncryptedDataBagItem.load_secret
        50:              Chef::EncryptedDataBagItem.new(raw_hash, secret)
        51:            end

        53:            raw_hash
        54:          end
        55:        rescue Chef::Exceptions::ValidationFailed,
        56:          Chef::Exceptions::InvalidDataBagPath,


       Running handlers:

       Running handlers complete
       [2015-02-03T23:14:00+00:00] ERROR: Exception handlers complete

       Chef Client failed. 0 resources updated in 7.727011328 seconds
       [2015-02-03T23:14:00+00:00] ERROR: undefined method `chef_vault_item' for Sensu::Helpers:Class
       [2015-02-03T23:14:02+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```