### PR TITLE
add subdue and dependencies to check resource

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -9,8 +9,8 @@ action :create do
   check = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type command timeout subscribers standalone aggregate handle
-      handlers publish low_flap_threshold high_flap_threshold
+      type command timeout subscribers standalone aggregate handle handlers
+      publish subdue dependencies low_flap_threshold high_flap_threshold
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -10,6 +10,8 @@ attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array
 attribute :publish, :kind_of => [TrueClass, FalseClass]
+attribute :subdue, :kind_of => Hash
+attribute :dependencies, :kind_of => Array
 attribute :low_flap_threshold, :kind_of => Integer
 attribute :high_flap_threshold, :kind_of => Integer
 attribute :additional, :kind_of => Hash, :default => Hash.new


### PR DESCRIPTION
Wanted to start using the "subdue" option in my checks, but discovered it wasn't in the Sensu-Chef cookbook yet.  Also added the "dependencies" option as that seems new too.