### PR TITLE
Add sensitive to certain file creation calls

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,6 +80,7 @@ if node.sensu.use_ssl
     owner node.sensu.admin_user
     group node.sensu.group
     mode 0640
+    sensitive true
   end
 else
   if node.sensu.rabbitmq.port == 5671

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -80,7 +80,7 @@ if node.sensu.use_ssl
     owner node.sensu.admin_user
     group node.sensu.group
     mode 0640
-    sensitive true
+    sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
   end
 else
   if node.sensu.rabbitmq.port == 5671

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -46,7 +46,7 @@ if node.sensu.use_ssl
       content ssl["server"][item]
       group "rabbitmq"
       mode 0640
-      sensitive true
+      sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
     end
     node.override.rabbitmq["ssl_#{item}"] = path
   end
@@ -62,7 +62,7 @@ if node.sensu.use_ssl
       content ssl["client"][item]
       group "rabbitmq"
       mode 0640
-      sensitive true
+      sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
     end
   end
 end

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -46,6 +46,7 @@ if node.sensu.use_ssl
       content ssl["server"][item]
       group "rabbitmq"
       mode 0640
+      sensitive true
     end
     node.override.rabbitmq["ssl_#{item}"] = path
   end
@@ -61,6 +62,7 @@ if node.sensu.use_ssl
       content ssl["client"][item]
       group "rabbitmq"
       mode 0640
+      sensitive true
     end
   end
 end


### PR DESCRIPTION
This will help improve security by not logging sensitive information (specifically SSL private keys, not really the public cert). I believe I've gotten all the pertinent file calls that could reveal sensitive information, but feel free to correct me and I'll update the PR.