### PR TITLE
Support log_level setting on Windows

### DIFF
--- a/templates/default/sensu.xml.erb
+++ b/templates/default/sensu.xml.erb
@@ -16,4 +16,6 @@
   <argument><%= node["sensu"]["directory"] %>\extensions</argument>
   <argument>-l</argument>
   <argument><%= node["sensu"]["log_directory"] %>\<%= @service %>.log</argument>
+  <argument>-L</argument>
+  <argument><%= node["sensu"]["log_level"] %></argument>
 </service>


### PR DESCRIPTION
This PR modifies the Windows Service Wrapper config file `sensu.xml.erb` to pass the "-L" argument to specify the log level. It uses the existing attribute `node["sensu"]["log_level"]` as the argument value.
