### PR TITLE
Ignoring Berksfile to permit ChefDK users to use a local Berksfile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/ssl/sensu_ca
 .kitchen/
 .kitchen.local.yml
 tmp
+Berksfile


### PR DESCRIPTION
We don't use Berks, and because Kitchen forces you to Berks if a Berksfile is present, adding one will break our ability to run test suites. 

Ignoring the Berksfile will allow anyone to use one in their local clone, without it accidentally getting committed and blocking an otherwise :+1: PR.