### PR TITLE
#373 Modify package and config template subscriptions to result in im…

### DIFF
--- a/recipes/enterprise_service.rb
+++ b/recipes/enterprise_service.rb
@@ -18,8 +18,8 @@
 #
 
 service "sensu-enterprise" do
-  subscribes :restart, resources("package[sensu-enterprise]"), :delayed
-  subscribes :restart, resources("template[/etc/default/sensu-enterprise]"), :delayed
+  subscribes :restart, resources("package[sensu-enterprise]"), :immediately
+  subscribes :restart, resources("template[/etc/default/sensu-enterprise]"), :immediately
   subscribes :reload, resources("ruby_block[sensu_service_trigger]"), :delayed
   supports :status => true, :start => true, :stop => true, :restart => true, :reload => true
   action [:enable, :start]


### PR DESCRIPTION
…mediate restart instead of delayed. This prevents the service receiving rapid back to back restart and reload requests when either the package or template change along with config changes