### PR TITLE
fix dependency for chef-vault in current stable release

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "rabbitmq", ">= 2.0.0"
 depends "redisio", ">= 1.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
-suggests "chef-vault", ">= 1.2.0"
+suggests "chef-vault", "<= 1.3.0"
 
 %w[
   ubuntu


### PR DESCRIPTION
* new release of chef-vault 1.3.1 changed module name from ChefVaultItem to
  ChefVaultCookbook

fixes #375