### PR TITLE
fix dependency and extension for chef-vault in next release

### DIFF
--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -2,7 +2,7 @@ require "openssl"
 
 module Sensu
   class Helpers
-    extend ChefVaultItem if Kernel.const_defined?("ChefVaultItem")
+    extend ChefVaultCookbook if Kernel.const_defined?("ChefVaultCookbook")
     class << self
       def select_attributes(attributes, keys)
         attributes.to_hash.reject do |key, value|

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "rabbitmq", ">= 2.0.0"
 depends "redisio", ">= 1.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
-suggests "chef-vault", ">= 1.2.0"
+suggests "chef-vault", ">= 1.3.1"
 
 %w[
   ubuntu


### PR DESCRIPTION
* new release of chef-vault 1.3.1 breaks extension of ChefVaultItem since it was
  moved to ChefVaultCookbook
* updated the metadata to suggest chef-vault >= 1.3.1
* adapted libraries/sensu_helpers.rb to extend with module ChefVaultCookbook

fixes #376