### PR TITLE
Add basic unit tests using ChefSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--default-path test/unit
+--color
+--format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source "https://rubygems.org"
 
 group :integration do
-  gem "chefspec", "~> 4.2"
+  gem "chef", "< 12.4"
+  gem "chefspec", "~> 4.5"
   gem "test-kitchen", ">= 1.2.1"
   gem "kitchen-vagrant"
   gem "kitchen-docker"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 group :integration do
+  gem "chefspec", "~> 4.2"
   gem "test-kitchen", ">= 1.2.1"
   gem "kitchen-vagrant"
   gem "kitchen-docker"

--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -1,0 +1,20 @@
+# specify resource without action for testing default action == :install
+sensu_gem 'sensu-plugins-sensu'
+
+# explicitly specify :install action for additional tests
+sensu_gem 'sensu-plugins-slack' do
+  action :install
+end
+
+# ensure we pass the specified version
+sensu_gem 'sensu-plugins-chef' do
+  version '0.0.5'
+  action :install
+end
+
+# for testing remove action
+sensu_gem 'sensu-plugins-hipchat' do
+  action :remove
+end
+
+

--- a/test/unit/client_service_spec.rb
+++ b/test/unit/client_service_spec.rb
@@ -1,0 +1,20 @@
+require_relative "spec_helper"
+
+describe "sensu::client_service" do
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+      # allow(node).to receive(:chef_environment).and_return(env.name)
+      # server.create_environment(env.name, { description: "an environment for unit tests" })
+      # server.create_data_bag("sensu", sensu_data_bag)
+      # server.create_node(rabbitmq_node_name, rabbitmq_node_attrs)
+    end.converge(described_recipe)
+  end
+
+  it "enables the sensu-client service" do
+    expect(chef_run).to enable_sensu_service("sensu-client")
+  end
+
+  it "starts the sensu-client service" do
+    expect(chef_run).to start_sensu_service("sensu-client")
+  end
+end

--- a/test/unit/common_examples.rb
+++ b/test/unit/common_examples.rb
@@ -1,0 +1,51 @@
+RSpec.shared_examples 'sensu default recipe' do
+  it "creates the log directory" do
+    expect(chef_run).to create_directory(log_directory).with(
+      :owner => 'sensu',
+      :group => 'sensu',
+      :recursive => true,
+      :mode => "0750"
+    )
+  end
+
+  %w[
+      conf.d
+      plugins
+      handlers
+      extensions
+    ].each do |dir|
+    it "creates the #{dir} directory" do
+      expect(chef_run).to create_directory(File.join(sensu_directory, dir))
+    end
+  end
+
+  let(:ssl_cert_chain_file) { File.join(sensu_directory, 'ssl', 'cert.pem') }
+  let(:ssl_private_key_file) { File.join(sensu_directory, 'ssl', 'key.pem') }
+
+  context 'ssl is enabled' do
+    it "writes the certificate chain file" do
+      expect(chef_run).to create_file(ssl_cert_chain_file)
+    end
+
+    it "writes the private key file" do
+      expect(chef_run).to create_file(ssl_private_key_file)
+    end
+  end
+
+  context 'ssl is disabled' do
+
+    before do
+      chef_run.node.set["sensu"]["use_ssl"] = false
+      chef_run.converge(described_recipe)
+    end
+    
+    it "does not write the certificate chain file" do
+      expect(chef_run).to_not create_file(ssl_cert_chain_file)
+    end
+
+    it "does not write the private key file" do
+      expect(chef_run).to_not create_file(ssl_private_key_file)
+    end
+  end
+
+end

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -1,0 +1,50 @@
+require_relative "spec_helper"
+require_relative "common_examples"
+
+describe "sensu::default" do
+  include_context("sensu data bags")
+
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_call_original
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with("sensu::_windows")
+  end
+
+  context "when running on non-windows platform" do
+
+    let(:sensu_directory) { '/etc/sensu' }
+    let(:log_directory) { '/var/log/sensu' }
+
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+        server.create_data_bag("sensu", ssl_data_bag_item)
+      end.converge(described_recipe)
+    end
+
+    it "includes the sensu::_linux recipe" do
+      expect(chef_run).to include_recipe("sensu::_linux")
+    end
+
+    it_behaves_like('sensu default recipe')
+  end
+
+  context "when running on windows platform" do
+
+    let(:sensu_directory) { 'C:\etc\sensu' }
+    let(:log_directory) { 'C:\var\log\sensu' }
+
+    let(:chef_run) do
+      ChefSpec::ServerRunner.new(:platform => "windows", :version => "2003R2") do |node, server|
+        server.create_data_bag("sensu", ssl_data_bag_item)
+        node.set["lsb"] = {}
+      end.converge(described_recipe)
+    end
+
+    it "includes the sensu::_windows recipe" do
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with("sensu::_windows")
+      chef_run
+    end
+
+    it_behaves_like('sensu default recipe')
+  end
+
+end

--- a/test/unit/libraries/sensu_helpers_spec.rb
+++ b/test/unit/libraries/sensu_helpers_spec.rb
@@ -5,9 +5,9 @@ require_relative '../../../libraries/sensu_helpers.rb'
 describe Sensu::Helpers do
 
   let(:node) { Fauxhai.mock(:platform => 'ubuntu', :version => '14.04').data }
+  let(:omnibus_gem_path) { '/opt/sensu/embedded/bin/gem' }
 
   describe ".select_attributes" do
-
     context 'when the requested attribute exists' do
       it 'returns the requested key/value pair' do
         results = Sensu::Helpers.select_attributes(node, 'platform')
@@ -35,6 +35,31 @@ describe Sensu::Helpers do
         results = Sensu::Helpers.select_attributes(node, ['platform_version', 'platform_lasagna'])
         expect(results.keys).to eq(['platform_version'])
         expect(results.values).to eq(['14.04'])
+      end
+    end
+  end
+
+  describe ".gem_binary" do
+    context 'with omnibus ruby available' do
+      before do
+        allow(File).to receive(:exists?).with(omnibus_gem_path).and_return(true)
+      end
+
+      it 'returns the full path to the omnibus ruby gem binary' do
+        gem_binary = Sensu::Helpers.gem_binary
+        expect(gem_binary).to eq(omnibus_gem_path)
+      end
+    end
+
+    context 'without omnibus ruby available' do
+
+      before do
+        allow(File).to receive(:exists?).with(omnibus_gem_path).and_return(false)
+      end
+
+      it 'returns an unqualified path to the gem binary' do
+        gem_binary = Sensu::Helpers.gem_binary
+        expect(gem_binary).to eq('gem')
       end
     end
   end

--- a/test/unit/libraries/sensu_helpers_spec.rb
+++ b/test/unit/libraries/sensu_helpers_spec.rb
@@ -1,0 +1,41 @@
+require 'rspec'
+require 'fauxhai'
+require_relative '../../../libraries/sensu_helpers.rb'
+
+describe Sensu::Helpers do
+
+  let(:node) { Fauxhai.mock(:platform => 'ubuntu', :version => '14.04').data }
+
+  describe ".select_attributes" do
+
+    context 'when the requested attribute exists' do
+      it 'returns the requested key/value pair' do
+        results = Sensu::Helpers.select_attributes(node, 'platform')
+        expect(results.keys).to eq(['platform'])
+        expect(results.values).to eq(['ubuntu'])
+      end
+    end
+
+    context 'when the requested attribute does not exist' do
+      it 'returns an empty hash' do
+        expect(Sensu::Helpers.select_attributes(node, 'hotdog')).to be_empty
+      end
+    end
+
+    context 'when multiple attributes are requested and all exist' do
+      it 'returns a hash containing the requested key/value pairs' do
+        results = Sensu::Helpers.select_attributes(node, ['fqdn', 'ipaddress'])
+        expect(results.keys).to eq(['fqdn', 'ipaddress'])
+        expect(results.values).to eq(['fauxhai.local', '10.0.0.2'])
+      end
+    end
+
+    context 'when multiple attributes are requested and only a subset exist' do
+      it 'returns a hash containing the existing key/value pairs' do
+        results = Sensu::Helpers.select_attributes(node, ['platform_version', 'platform_lasagna'])
+        expect(results.keys).to eq(['platform_version'])
+        expect(results.values).to eq(['14.04'])
+      end
+    end
+  end
+end

--- a/test/unit/libraries/sensu_json_file_spec.rb
+++ b/test/unit/libraries/sensu_json_file_spec.rb
@@ -1,0 +1,63 @@
+require 'chefspec'
+require_relative '../../../libraries/sensu_json_file.rb'
+
+describe 'Sensu::JSONFile' do
+
+  let(:config) do
+    {
+      "client" => { "name" => "test", "address" => "localhost", "subscriptions" => [ "test" ] },
+      "rabbitmq" => { "host" => "172.16.100.100", "port" => 5671, "vhost" => "/sensu", "user" => "sensu", "password" => "sensu" }
+    }
+  end
+
+  let(:stubbed_file_content) { config.to_json }
+  let(:stubbed_file_path) { '/tmp/foo.json' }
+
+  before(:each) do
+    allow(File).to receive(:read).with(stubbed_file_path).and_return(stubbed_file_content)
+  end
+
+  describe ".load_json" do
+   
+    it 'returns a non-empty hash' do
+      result = Sensu::JSONFile.load_json(stubbed_file_path)
+      expect(result).to be_a(Hash)
+      expect(result.empty?).to eq(false)
+    end
+
+    it 'returns a hash containing the expected keys' do
+      result = Sensu::JSONFile.load_json(stubbed_file_path)
+      expect(result.keys).to eq(['client', 'rabbitmq'])
+    end
+  end
+
+  describe ".dump_json" do
+    it 'returns a non-empty string, terminated with a new line' do
+      result = Sensu::JSONFile.dump_json(config)
+      expect(result).to be_a(String)
+      expect(result).to match(/^.*\n$/)
+    end
+  end
+
+  describe ".to_mash" do
+    it 'converts a hash into a mash' do
+      result = Sensu::JSONFile.to_mash(config)
+      expect(result).to be_a(Mash)
+      expect(result.keys).to eq(config.keys)
+      expect(result.values).to eq(config.values)
+    end
+  end
+
+  describe ".compare_content" do
+    it 'returns false when comparing the content of a file to a non-matching hash' do
+      result = Sensu::JSONFile.compare_content(stubbed_file_path, {})
+      expect(result).to eq(false)
+    end
+
+    it 'returns true when comparing the content of a file to a matching hash' do
+      result = Sensu::JSONFile.compare_content(stubbed_file_path, config)
+      expect(result).to eq(true)
+    end
+  end
+
+end

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -1,0 +1,30 @@
+require_relative "../spec_helper"
+
+describe 'sensu-test::gem_lwrp' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(:step_into => ['sensu_gem']).converge(described_recipe)
+  end
+
+  it 'defaults to action :install' do
+    expect(chef_run).to install_gem_package('sensu-plugins-sensu')
+  end
+
+  context 'action :install' do
+    it 'installs the specified gem package' do
+      expect(chef_run).to install_gem_package('sensu-plugins-slack')
+    end
+
+    context 'version specified' do
+      it 'installs the specified version of the gem package' do
+        expect(chef_run).to install_gem_package('sensu-plugins-chef').with(:version => '0.0.5')
+      end
+    end
+  end
+
+  context 'action :remove' do
+    it 'removes the specified gem package' do
+      expect(chef_run).to remove_gem_package('sensu-plugins-hipchat')
+    end
+  end
+
+end

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -1,0 +1,27 @@
+require 'chefspec'
+require 'chefspec/librarian'
+
+RSpec.shared_context('sensu data bags') do
+  let(:ssl_data_bag_item) do
+    # JSON.parse(
+    #   File.read(File.join(File.dirname(__FILE__), '../integration/data_bags/sensu/ssl.json'))
+    # )
+    {
+      'ssl' => {
+        'client' => {
+          'cert' => '',
+          'key' => ''
+        },
+        'server' => {
+          'cert' => '',
+          'key' => '',
+          'cacert' => ''
+        }
+      },
+      'config' => {
+      },
+      'enterprise' => {
+      }
+    }
+  end
+end


### PR DESCRIPTION
First pass at adding unit tests. Covers setting up directories, writing (or not writing) SSL credentials to disk, and inclusion of the correct platform-specific recipe.

```
sensu::client_service
  enables the sensu-client service
  starts the sensu-client service

sensu::default
  when running on non-windows platform
    includes the sensu::_linux recipe
    behaves like sensu default recipe
      creates the log directory
      creates the conf.d directory
      creates the plugins directory
      creates the handlers directory
      creates the extensions directory
      ssl is enabled
        writes the certificate chain file
        writes the private key file
      ssl is disabled
        does not write the certificate chain file
        does not write the private key file
  when running on windows platform
    includes the sensu::_windows recipe
    behaves like sensu default recipe
      creates the log directory
      creates the conf.d directory
      creates the plugins directory
      creates the handlers directory
      creates the extensions directory
      ssl is enabled
        writes the certificate chain file
        writes the private key file
      ssl is disabled
        does not write the certificate chain file
        does not write the private key file

Finished in 1 minute 53.26 seconds (files took 1.4 seconds to load)
22 examples, 0 failures
```