### PR TITLE
Have json_file resource create owner user and group if necessary

### DIFF
--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -8,6 +8,22 @@ action :create do
   end
 
   unless Sensu::JSONFile.compare_content(new_resource.path, new_resource.content)
+    if new_resource.group == node["sensu"]["group"]
+      group new_resource.group do
+        system true
+      end
+    end
+
+    if @owner == node["sensu"]["user"]
+      user @owner do
+        system true
+        group new_resource.group
+        home '/opt/sensu'
+        shell '/bin/false'
+        comment 'Sensu Monitoring Framework'
+      end
+    end
+
     directory ::File.dirname(new_resource.path) do
       recursive true
       owner @owner


### PR DESCRIPTION
Currently, the sensu user and group are created by the package installation.  The json_file resource creates files owned by that user but there are no provisions in the Chef recipes for creating that
user.  That makes it hard to test recipes that create Sensu configuration snippets without setting up a Sensu client.

Instead, the json_file resource should create the user and group as necessary.

This implementation probably has some issues, so it's more of a conversation starter. But it works for my purposes.