### PR TITLE
prefer Chef::ReservedNames::Win32::Version for determining windows version

### DIFF
--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -17,7 +17,8 @@
 # limitations under the License.
 #
 
-Chef::Recipe.send(:include, Windows::Helper)
+require 'chef/win32/version'
+win_version = Chef::ReservedNames::Win32::Version.new
 
 user "sensu" do
   password Sensu::Helpers.random_password(20, true, true, true, true)


### PR DESCRIPTION
Per #397 and https://github.com/chef-cookbooks/windows/issues/335, the facilities for determining windows version provided in Chef::ReservedNames::Win32 version are prefered over the helpers provided by the `windows` cookbook's library. 

My background research shows this should work going back to Chef 10, so I am satisfied that this is not likely to be a breaking change.