### PR TITLE
Default group should be the group specified by the attributes

### DIFF
--- a/resources/json_file.rb
+++ b/resources/json_file.rb
@@ -2,7 +2,7 @@ actions :create, :delete
 
 attribute :path, :name_attribute => true
 attribute :owner, :kind_of => String
-attribute :group, :kind_of => String, :default => 'sensu'
+attribute :group, :kind_of => String, :default => node['sensu']['group']
 attribute :mode, :kind_of => [String, Integer], :default => 0640
 attribute :content, :kind_of => Hash
 


### PR DESCRIPTION
If you try and change the group sensu, the sensu processes can't read any of the files since they always default to the 'sensu' group. This fixes that issue.