### PR TITLE
Use sensu.user and sensu.group node attribute values as defaults for sensu_file_json ownership

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,7 @@ platforms:
 suites:
   - name: default
     run_list:
+      - recipe[sensu-test::ensure_group.rb]
       - recipe[sensu::default]
     attributes:
       sensu:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,6 +29,7 @@ suites:
       - recipe[sensu::default]
     attributes:
       sensu:
+        group: nogroup
         windows:
           dism_source: <%= ENV['SENSU_WINDOWS_DISM_SOURCE'] %>
   - name: sysv

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,7 +26,7 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[sensu-test::ensure_group.rb]
+      - recipe[sensu-test::ensure_group]
       - recipe[sensu::default]
     attributes:
       sensu:

--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -1,7 +1,3 @@
-def load_current_resource
-  @owner = new_resource.owner || node["sensu"]["admin_user"]
-end
-
 action :create do
   sensu_service_trigger = !!node.run_context.resource_collection.detect do |r|
     r.to_s == "ruby_block[sensu_service_trigger]"
@@ -10,14 +6,14 @@ action :create do
   unless Sensu::JSONFile.compare_content(new_resource.path, new_resource.content)
     directory ::File.dirname(new_resource.path) do
       recursive true
-      owner @owner
-      group new_resource.group
+      owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
+      group lazy { new_resource.group || node["sensu"]["group"] }
       mode 0750
     end
 
     f = file new_resource.path do
-      owner @owner
-      group new_resource.group
+      owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
+      group lazy { new_resource.group || node["sensu"]["group"] }
       mode new_resource.mode
       content Sensu::JSONFile.dump_json(new_resource.content)
       notifies :create, "ruby_block[sensu_service_trigger]", :delayed if sensu_service_trigger

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -20,18 +20,16 @@
 require 'chef/win32/version'
 win_version = Chef::ReservedNames::Win32::Version.new
 
-user node["sensu"]["user"] do
+user "sensu" do
   password Sensu::Helpers.random_password(20, true, true, true, true)
   not_if {
-    lazy {
-      user = Chef::Util::Windows::NetUser.new(node["sensu"]["user"])
-      !!user.get_info rescue false
-    }
+    user = Chef::Util::Windows::NetUser.new("sensu")
+    !!user.get_info rescue false
   }
 end
 
-group node["sensu"]["group"] do
-  members node["sensu"]["user"]
+group "sensu" do
+  members "sensu"
   action :manage
 end
 

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -20,16 +20,18 @@
 require 'chef/win32/version'
 win_version = Chef::ReservedNames::Win32::Version.new
 
-user "sensu" do
+user node["sensu"]["user"] do
   password Sensu::Helpers.random_password(20, true, true, true, true)
   not_if {
-    user = Chef::Util::Windows::NetUser.new("sensu")
-    !!user.get_info rescue false
+    lazy {
+      user = Chef::Util::Windows::NetUser.new(node["sensu"]["user"])
+      !!user.get_info rescue false
+    }
   }
 end
 
-group "sensu" do
-  members "sensu"
+group node["sensu"]["group"] do
+  members node["sensu"]["user"]
   action :manage
 end
 

--- a/resources/json_file.rb
+++ b/resources/json_file.rb
@@ -1,8 +1,9 @@
 actions :create, :delete
 
 attribute :path, :name_attribute => true
+# owner and group attributes have defaults set in the provider
 attribute :owner, :kind_of => String
-attribute :group, :kind_of => String, :default => 'sensu'
+attribute :group, :kind_of => String
 attribute :mode, :kind_of => [String, Integer], :default => 0640
 attribute :content, :kind_of => Hash
 

--- a/test/cookbooks/sensu-test/recipes/ensure_group.rb
+++ b/test/cookbooks/sensu-test/recipes/ensure_group.rb
@@ -1,0 +1,1 @@
+group "nogroup"

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -3,4 +3,5 @@ require 'spec_helper'
 describe file("/etc/sensu/config.json") do
   its(:content) { should match /"name": "test"/ }
   its(:content) { should_not match /"id": / }
+  it { should be_grouped_into('nogroup') }
 end


### PR DESCRIPTION
Closes #422 and #389 

Prior to this change the default group for a sensu_json_file resource was hardcoded to 'sensu' as a string.

In #422 it is suggested to use the value of node['sensu']['group'] attribute to set this default, but the implementation in that PR is problematic due to the attribute being evaluated when the cookbook loads.

In #389 it is suggested to have the sensu_json_file resource manage the user and group for its owner and group, respectively. I'd rather not manage this aspect off the system from what's intended as a simple wrapper around the file resource.

I believe that if we lazily evaluate the 'admin_user' and 'group' attributes as defaults for the sensu_json_file resource we will make it possible for folks to avoid having to create 'sensu' user/group when they are trying to test sensu_json_file resources in isolation.