### PR TITLE
Restore windows testing via SSH, omit Windows suites in Rakefile

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,9 +9,17 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
+    driver:
+      box: opscode-ubuntu-12.04
   - name: ubuntu-14.04
+    driver:
+      box: opscode-ubuntu-14.04
   - name: centos-5.10
+    driver:
+      box: opscode-centos-5.10
   - name: centos-6.5
+    driver:
+      box: opscode-centos-6.5
   - name: windows-2012-r2
     driver:
       http_proxy: null

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,6 +19,8 @@ platforms:
       box: windows_2012_r2
       customize:
         memory: 2048
+    provisioner:
+      windows_chef_zero
     attributes:
       lsb:
         codename: windows

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,10 @@ source "https://rubygems.org"
 group :integration do
   gem "chef", "< 12.4"
   gem "chefspec", "~> 4.5"
-  gem "test-kitchen", ">= 1.2.1"
-  gem "kitchen-vagrant", "~> 0.17"
-  gem "winrm-transport"
+  gem "test-kitchen", "= 1.3.1"
+  gem "kitchen-vagrant", "= 0.16.0"
+  gem "winrm-transport", ">= 1.0.3"
   gem "kitchen-docker"
   gem "librarian-chef"
+  gem "windows_chef_zero", ">= 1.0.0"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,34 @@
+#!/usr/bin/env rake
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.pattern = [ 'test/unit/**{,/*/**}/*_spec.rb' ]
+  end
+rescue LoadError
+end
+
+begin
+  require 'kitchen/rake_tasks'
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+end
+
+# for now we're blacklisting windows platforms in rake tasks
+# but keeping them in .kitchen.yml so we can still run as needed
+%w(
+  default-windows-2012-r2
+  asset-windows-2012-r2
+).each do |suite|
+  if Rake::Task.task_defined?("kitchen:#{suite}")
+
+    filtered_tasks = Rake::Task['kitchen:all'].prerequisite_tasks.reject {
+      |t| t.name == "kitchen:#{suite}"
+    }
+
+    Rake::Task['kitchen:all'].clear
+    Rake::Task['kitchen:all'].enhance(filtered_tasks)
+    Rake.application.instance_variable_get('@tasks').delete("kitchen:#{suite}")
+  end
+end

--- a/TESTING.md
+++ b/TESTING.md
@@ -23,7 +23,7 @@ bundle exec rake spec
 Integration tests are setup to run under test-kitchen:
 
 ```
-bundle exec kitchen test
+bundle exec rake kitchen:all
 ```
 
 This tests a number of different suites, some of which require special credentials or virtual machine configurations. Please see the caveats and known issues below for additional details.
@@ -32,5 +32,6 @@ This tests a number of different suites, some of which require special credentia
 
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.
+* Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task
 * Testing Windows platforms requires you to Bring Your Own Basebox. See https://github.com/boxcutter/windows for a Packer template.
-* Be advised that even once you have a Windows basebox built from one of the boxcutter, you may not be able to install the required version of Microsoft .Net Framework without manual intervention (e.g. attaching installation media as a shared folder and exporting the path as the value of the `SENSU_WINDOWS_DISM_SOURCE` environment variable. See [this issue on the sensu/sensu-build project](https://github.com/sensu/sensu-build/issues/149) for more details.
+* Testing Windows platforms currently uses the converge-only windows_chef_zero provisioner. Running `kitchen verify` or `kitchen test` on instances using this provisioner will fail.


### PR DESCRIPTION
Per #423, this PR restores Windows testing via SSH using windows_chef_zero provisioner. Gem version restrictions are introduced here to ensure this hack can run. Also adding Rakefile which is referenced in our testing documentation but apparently not committed? This one omits the Windows suites from the rake tasks because they are a special case. :tada: 