### PR TITLE
Rename Windows base box from windows_2012_r2 to windows-2012r2

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -24,7 +24,7 @@ platforms:
     driver:
       http_proxy: null
       https_proxy: null
-      box: windows_2012_r2
+      box: windows-2012r2
       customize:
         memory: 2048
     provisioner:

--- a/TESTING.md
+++ b/TESTING.md
@@ -32,6 +32,6 @@ This tests a number of different suites, some of which require special credentia
 
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.
-* Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task
+* Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task. You may test them manually via `bundle exec kitchen converge` but `verify` and `test` will fail.
 * Testing Windows platforms requires you to Bring Your Own Basebox. See https://github.com/boxcutter/windows for a Packer template.
 * Testing Windows platforms currently uses the converge-only windows_chef_zero provisioner. Running `kitchen verify` or `kitchen test` on instances using this provisioner will fail.

--- a/TESTING.md
+++ b/TESTING.md
@@ -33,5 +33,5 @@ This tests a number of different suites, some of which require special credentia
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.
 * Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task. You may test them manually via `bundle exec kitchen converge` but `verify` and `test` will fail.
-* Testing Windows platforms requires you to Bring Your Own Basebox. See https://github.com/boxcutter/windows for a Packer template.
+* Testing Windows platforms requires you to Bring Your Own Basebox. See https://github.com/joefitzgerald/packer-windows for a Packer template that includes OpenSSH.
 * Testing Windows platforms currently uses the converge-only windows_chef_zero provisioner. Running `kitchen verify` or `kitchen test` on instances using this provisioner will fail.


### PR DESCRIPTION
This change is intended to provide consistency with other projects
where we are running Windows under test-kitchen (e.g. omnibus_updater).