### PR TITLE
switch centos-5.10 for centos-5.11

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,17 +9,9 @@ provisioner:
 
 platforms:
   - name: ubuntu-12.04
-    driver:
-      box: opscode-ubuntu-12.04
   - name: ubuntu-14.04
-    driver:
-      box: opscode-ubuntu-14.04
-  - name: centos-5.10
-    driver:
-      box: opscode-centos-5.10
+  - name: centos-5.11
   - name: centos-6.5
-    driver:
-      box: opscode-centos-6.5
   - name: windows-2012-r2
     driver:
       http_proxy: null
@@ -48,6 +40,7 @@ suites:
       - recipe[sensu-test]
     excludes:
       - windows-2012-r2
+      - centos-5.11
   - name: runit
     run_list:
       - recipe[sensu-test::runit]


### PR DESCRIPTION
A few things:

The sysv platform suite is failing on both versions of centos 5 because /usr/sbin is not in root's default $PATH; rabbitmqctl fails to execute as a result.

In bdd21cd900e9477c2394967f2e376b3ff5ee193c I added explicit box names for all of our test platforms because the version of test-kitchen we now need for windows_chef_zero compatability cannot automatically resolve centos-5.10 to an opscode-
published box name.

Quickly surveying other cookbook projects I see that centos-5.11 is the version of centos 5 being tested by many. We'll update to that, with the understanding that this test suite is broken, and exclude it from that suite. As a result, we can drop the explicit box names.