### PR TITLE
exclude centos platform on sysv suite

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -59,6 +59,7 @@ suites:
       - recipe[sensu-test]
     excludes:
       - windows-2012-r2
+      - centos-5.11
     attributes:
       sensu:
         rabbitmq:
@@ -68,6 +69,7 @@ suites:
       - recipe[sensu-test]
     excludes:
       - windows-2012-r2
+      - centos-5.11
     attributes:
       dev_mode: true
   - name: asset

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,7 @@ suites:
     excludes:
       - windows-2012-r2
       - centos-5.11
+      - centos-6.5
   - name: runit
     run_list:
       - recipe[sensu-test::runit]

--- a/TESTING.md
+++ b/TESTING.md
@@ -30,6 +30,8 @@ This tests a number of different suites, some of which require special credentia
 
 ### Caveats and known issues
 
+* The centos-65 platform is currently excluded from `sysv` suite, as RabbitMQ [disables SSL listeners under the currently installed version of Erlang (R14B04)](http://www.rabbitmq.com/ssl.html#old-erlang).
+* The centos-511 platform is also excluded from the `sysv` suite because the "rabbitmqctl" executable is not in root's path, which causes rabbitmq configuration to fail.
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.
 * Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task. You may test them manually via `bundle exec kitchen converge` but `verify` and `test` will fail.


### PR DESCRIPTION
The version of erlang present on centos 6 does not meet the [minimum requirements for SSL under rabbitmq 3.4 and later](http://www.rabbitmq.com/ssl.html#old-erlang). This means our serverspec tests fail because port 5671 is not listening.

Work arounds include enabling `ssl_allow_poodle_attack` in the rabbitmq config, or providing a newer version of erlang in the installation. 

Since we are targeting installation of erlang via Erlang Solutions repos for 3.0 in #411, I think we should just punt on this and exclude centos platforms from `sysv` suite until we can address this in 3.0.

(centos 5.11 was disabled in sysv suite via https://github.com/sensu/sensu-chef/pull/431)