### PR TITLE
stubbing Chef file_cache_path in sensu_gem lwrp specs

### DIFF
--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -2,7 +2,10 @@ require_relative "../spec_helper"
 
 describe 'sensu-test::gem_lwrp' do
   let(:chef_run) do
-    ChefSpec::SoloRunner.new(:step_into => ['sensu_gem']).converge(described_recipe)
+    ChefSpec::SoloRunner.new(
+      :step_into => ['sensu_gem'],
+      :file_cache_path => '/tmp'
+    ).converge(described_recipe)
   end
 
   it 'defaults to action :install' do


### PR DESCRIPTION
## Description

Configuring `file_cache_path` on the `Chef::SoloRunner` object in the `sensu_gem` ChefSpec tests to fix a broken test.

## Motivation and Context
Fixes the broken ChefSpec tests documented in #440. Closes #440.

## How Has This Been Tested?
Broken test now passes in my local environment (i.e. `bundle exec rake rspec`)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
