### PR TITLE
Replace use of windows_chef_zero with chef-zero-scheduled-task

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,14 +15,14 @@ platforms:
     driver:
       box: opscode-centos-6.5
   - name: windows-2012-r2
+    provisioner:
+      name: chef_zero_scheduled_task
     driver:
       http_proxy: null
       https_proxy: null
       box: windows-2012r2
       customize:
         memory: 2048
-    provisioner:
-      windows_chef_zero
     attributes:
       lsb:
         codename: windows

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
 end
 
 group :integration do
-  gem "chef-zero-scheduled-task"
+  gem "chef-zero-scheduled-task", "~> 0.1"
   gem "test-kitchen", "~> 1.7"
   gem "kitchen-docker"
   gem "kitchen-vagrant"

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,18 @@
 source "https://rubygems.org"
 
-group :integration do
-  gem "chef", "< 12.4"
+group :develop do
+  gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
-  gem "test-kitchen", "= 1.3.1"
-  gem "kitchen-vagrant", "= 0.16.0"
-  gem "winrm-transport", ">= 1.0.3"
-  gem "kitchen-docker"
-  gem "librarian-chef"
-  gem "windows_chef_zero", ">= 1.0.0"
   gem "emeril", "~> 0.8"
+  gem "librarian-chef"
+  gem "rake"
+end
+
+group :integration do
+  gem "chef-zero-scheduled-task"
+  gem "test-kitchen", "~> 1.7"
+  gem "kitchen-docker"
+  gem "kitchen-vagrant"
+  gem "winrm-fs"
+  gem "winrm-transport"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,21 +24,3 @@ begin
 rescue LoadError
   puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
 end
-
-# for now we're blacklisting windows platforms in test-kitchen rake tasks
-# but keeping them in .kitchen.yml so we can still run as needed via `kitchen` command
-%w(
-  default-windows-2012-r2
-  asset-windows-2012-r2
-).each do |suite|
-  if Rake::Task.task_defined?("kitchen:#{suite}")
-
-    filtered_tasks = Rake::Task['kitchen:all'].prerequisite_tasks.reject {
-      |t| t.name == "kitchen:#{suite}"
-    }
-
-    Rake::Task['kitchen:all'].clear
-    Rake::Task['kitchen:all'].enhance(filtered_tasks)
-    Rake.application.instance_variable_get('@tasks').delete("kitchen:#{suite}")
-  end
-end

--- a/TESTING.md
+++ b/TESTING.md
@@ -34,6 +34,4 @@ This tests a number of different suites, some of which require special credentia
 * The centos-511 platform is also excluded from the `sysv` suite because the "rabbitmqctl" executable is not in root's path, which causes rabbitmq configuration to fail.
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.
-* Windows tests are currently considered a special case, and therefore ommited when running the `kitchen:all` rake task. You may test them manually via `bundle exec kitchen converge` but `verify` and `test` will fail.
-* Testing Windows platforms requires you to Bring Your Own Basebox. See https://github.com/joefitzgerald/packer-windows for a Packer template that includes OpenSSH.
-* Testing Windows platforms currently uses the converge-only windows_chef_zero provisioner. Running `kitchen verify` or `kitchen test` on instances using this provisioner will fail.
+* Testing Windows platforms requires you to Bring Your Own Basebox.

--- a/test/integration/asset/serverspec/asset_spec.rb
+++ b/test/integration/asset/serverspec/asset_spec.rb
@@ -7,24 +7,26 @@ require 'spec_helper'
   check-socket.rb
   check-dns.rb
 ].each do |plugin|
-  describe file(File.join("/etc/sensu/plugins", plugin)) do
+  describe file(File.join(sensu_directory, "plugins", plugin)) do
     it { should be_file }
-    it { should be_mode 755 }
+    it { should be_mode 755 } unless windows?
     it { should be_owned_by "root" }
-    it { should be_grouped_into "sensu" }
+    it { should be_grouped_into "sensu" } unless windows?
   end
 end
 
-describe file("/etc/sensu/handlers/handler-pagerduty.rb") do
+describe file(File.join(sensu_directory, "handlers", "handler-pagerduty.rb")) do
   it { should be_file }
-  it { should be_mode 755 }
+  it { should be_mode 755 } unless windows?
   it { should be_owned_by "root" }
-  it { should be_grouped_into "sensu" }
+  it { should be_grouped_into "sensu" } unless windows?
 end
 
-describe file("/etc/sensu/extensions/system_profile.rb") do
+profiler_extension = windows? ? 'wmi_metrics.rb' : 'system_profile.rb'
+
+describe file(File.join(sensu_directory , "extensions", profiler_extension)) do
   it { should be_file }
-  it { should be_mode 755 }
+  it { should be_mode 755 } unless windows?
   it { should be_owned_by "root" }
-  it { should be_grouped_into "sensu" }
+  it { should be_grouped_into "sensu" } unless windows?
 end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe file("/etc/sensu/config.json") do
+describe file(File.join(sensu_directory, "config.json")) do
   its(:content) { should match /"name": "test"/ }
   its(:content) { should_not match /"id": / }
-  it { should be_grouped_into('nogroup') }
+  it { should be_grouped_into('nogroup') } unless windows?
 end

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -2,7 +2,31 @@ require "net/http"
 require 'serverspec'
 require "uri"
 
-set :backend, :exec
-set :path, "/bin:/usr/bin:/sbin:/usr/sbin"
+# h/t to @martinb3 for http://martinb3.io/testkitchen-serverspec-windows/
+if (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM).nil?
+  set :backend, :exec
+  set :path, "/bin:/usr/bin:/sbin:/usr/sbin:$PATH"
+else
+  set :backend, :cmd
+  set :os, :family => "windows"
+end
 
 puts "os: #{os}"
+
+# helper methods to conditionally guard individual tests by platform
+def linux?
+  %w(debian redhat ubuntu).include?(os[:family])
+end
+
+def windows?
+  %w(windows).include?(os[:family])
+end
+
+def sensu_directory
+  case windows?
+  when true
+    'C:\etc\sensu'
+  else
+    "/etc/sensu"
+  end
+end


### PR DESCRIPTION
## Description

As documented in our testing documentation and #423, a number of caveats apply to our current integration testing for Windows. Using the [chef-zero-scheduled-task](https://github.com/smurawski/chef-zero-scheduled-task) provisioner obviates these caveats.

Closes #423

## Motivation and Context

Because WinRM, the preferred test-kitchen transport for running Chef on Windows, does not allow .Net Framework to be installed using commands issued directly over WinRM, we currently depend on [windows_chef_zero](http://github.com/portertech/windows_chef_zero) provisioner and a Windows image with SSH daemon running. This is less than optimal because:

* windows_chef_zero only works on relatively old test-kitchen versions
* windows_chef_zero can't run verify phase, so testing is converge-only
* building windows base images isn't fun, we'd like to be able to use images we don't have to maintain w/ SSH

The chef-zero-scheduled-task provisioner circumvents this limitation by using WinRM transport to create a scheduled task for executing Chef during the test-kitchen converge phase. Running Chef from a scheduled task we are now able to successfully run Windows test suites using WinRM.

I have also updated the serverspec integration tests for the suites which we test on Windows so that they are passing.

## How Has This Been Tested?

`bundle exec kitchen test windows` now runs without errors
`bundle exec rake spec` runs without errors

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.