### PR TITLE
Add support for configuring Sensu Enterprise repository location via attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ for Sensu to start/stop.
 
 `node["sensu"]["api"]["port"]` - Sensu API port.
 
+### Sensu Enterprise
+
+`node["sensu"]["enterprise"]["repo_protocol"]` - Sensu Enterprise repo protocol (e.g. http, https)
+`node["sensu"]["enterprise"]["repo_host"]` - Sensu Enterprise repo host
+`node["sensu"]["enterprise"]["version"]` - Desired Sensu Enterprise package version
+`node["sensu"]["enterprise"]["use_unstable_repo"]` - Toggle use of Sensu Enterprise unstable repository
+`node["sensu"]["enterprise"]["log_level"]` - Configure Sensu Enterprise log level
+`node["sensu"]["enterprise"]["heap_size"]` - Configure Sensu Enterprise heap size
+
 ## LWRP'S
 
 ### Define a client

--- a/attributes/enterprise.rb
+++ b/attributes/enterprise.rb
@@ -1,4 +1,6 @@
 # installation
+default["sensu"]["enterprise"]["repo_protocol"] = "http"
+default["sensu"]["enterprise"]["repo_host"] = "enterprise.sensuapp.com"
 default["sensu"]["enterprise"]["version"] = "1.5.2-1"
 default["sensu"]["enterprise"]["use_unstable_repo"] = false
 default["sensu"]["enterprise"]["log_level"] = "info"

--- a/recipes/_enterprise_repo.rb
+++ b/recipes/_enterprise_repo.rb
@@ -1,0 +1,41 @@
+data_bag_name = node["sensu"]["data_bag"]["name"]
+enterprise_item = node["sensu"]["data_bag"]["enterprise_item"]
+
+begin
+  unless get_sensu_state(node, "enterprise")
+    enterprise = Sensu::Helpers.data_bag_item(enterprise_item, true, data_bag_name)
+    set_sensu_state(node, "enterprise", enterprise)
+   end
+rescue => e
+  Chef::Log.warn("Failed to populate Sensu state with Enterprise repository credentials from data bag: " + e.inspect)
+end
+
+credentials = get_sensu_state(node, "enterprise", "repository", "credentials")
+
+repository_url = case credentials.nil?
+                 when true
+                   "#{node["sensu"]["enterprise"]["repo_protocol"]}://#{node["sensu"]["enterprise"]["repo_host"]}"
+                 when false
+                   "#{node["sensu"]["enterprise"]["repo_protocol"]}://#{credentials['user']}:#{credentials['password']}@#{node["sensu"]["enterprise"]["repo_host"]}"
+                 end
+
+case node["platform_family"]
+when "debian"
+  include_recipe "apt"
+
+  apt_repository "sensu-enterprise" do
+    uri File.join(repository_url, "apt")
+    key File.join(repository_url, "apt", "pubkey.gpg")
+    distribution "sensu-enterprise"
+    components node["sensu"]["enterprise"]["use_unstable_repo"] ? ["unstable"] : ["main"]
+    action :add
+  end
+else
+  repo = yum_repository "sensu-enterprise" do
+    description "sensu enterprise"
+    repo = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
+    url "#{repository_url}/#{repo}/noarch/"
+    action :add
+  end
+  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
+end

--- a/recipes/enterprise.rb
+++ b/recipes/enterprise.rb
@@ -18,45 +18,7 @@
 #
 
 include_recipe "sensu"
-
-platform_family = node["platform_family"]
-platform_version = node["platform_version"].to_i
-
-data_bag_name = node["sensu"]["data_bag"]["name"]
-enterprise_item = node["sensu"]["data_bag"]["enterprise_item"]
-
-begin
-  unless get_sensu_state(node, "enterprise")
-    enterprise = Sensu::Helpers.data_bag_item(enterprise_item, true, data_bag_name)
-    set_sensu_state(node, "enterprise", enterprise)
-   end
-rescue => e
-    Chef::Log.warn("Failed to populate Sensu state with Enterprise repository credentials from data bag: " + e.inspect)
-end
-
-credentials = get_sensu_state(node, "enterprise", "repository", "credentials")
-repository_url = "http://#{credentials['user']}:#{credentials['password']}@enterprise.sensuapp.com"
-
-case platform_family
-when "debian"
-  include_recipe "apt"
-
-  apt_repository "sensu-enterprise" do
-    uri File.join(repository_url, "apt")
-    key File.join(repository_url, "apt", "pubkey.gpg")
-    distribution "sensu-enterprise"
-    components node["sensu"]["enterprise"]["use_unstable_repo"] ? ["unstable"] : ["main"]
-    action :add
-  end
-else
-  repo = yum_repository "sensu-enterprise" do
-    description "sensu enterprise"
-    repo = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
-    url "#{repository_url}/#{repo}/noarch/"
-    action :add
-  end
-  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
-end
+include_recipe "sensu::_enterprise_repo"
 
 package "sensu-enterprise" do
   version node["sensu"]["enterprise"]["version"]

--- a/recipes/enterprise_dashboard.rb
+++ b/recipes/enterprise_dashboard.rb
@@ -17,44 +17,7 @@
 # limitations under the License.
 #
 
-platform_family = node["platform_family"]
-platform_version = node["platform_version"].to_i
-
-data_bag_name = node["sensu"]["data_bag"]["name"]
-enterprise_item = node["sensu"]["data_bag"]["enterprise_item"]
-
-begin
-  unless get_sensu_state(node, "enterprise")
-    enterprise = Sensu::Helpers.data_bag_item(enterprise_item, true, data_bag_name)
-    set_sensu_state(node, "enterprise", enterprise)
-   end
-rescue => e
-  Chef::Log.warn("Failed to populate Sensu state with Enterprise repository credentials from data bag: " + e.inspect)
-end
-
-credentials = get_sensu_state(node, "enterprise", "repository", "credentials")
-repository_url = "http://#{credentials['user']}:#{credentials['password']}@enterprise.sensuapp.com"
-
-case platform_family
-when "debian"
-  include_recipe "apt"
-
-  apt_repository "sensu-enterprise" do
-    uri File.join(repository_url, "apt")
-    key File.join(repository_url, "apt", "pubkey.gpg")
-    distribution "sensu-enterprise"
-    components node["sensu"]["enterprise"]["use_unstable_repo"] ? ["unstable"] : ["main"]
-    action :add
-  end
-else
-  repo = yum_repository "sensu-enterprise-dashboard" do
-    description "sensu enterprise dashboard"
-    repo = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
-    url "#{repository_url}/#{repo}/$basearch/"
-    action :add
-  end
-  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
-end
+include_recipe "sensu::_enterprise_repo.rb"
 
 package "sensu-enterprise-dashboard" do
   version node["sensu"]["enterprise-dashboard"]["version"]

--- a/test/unit/enterprise_repo.rb
+++ b/test/unit/enterprise_repo.rb
@@ -1,0 +1,90 @@
+require_relative "spec_helper"
+
+describe "sensu::_enterprise_repo" do
+  let(:data_bag_item) do
+    {
+      "enterprise" => {
+        "repository" => {
+          "credentials" => {
+            "user" => "chefspec",
+            "password" => "moartests!"
+          }
+        }
+      }
+    }
+  end
+
+  %w(stable unstable).each do |repo_designation|
+    context "apt platforms" do
+      let(:chef_run) do
+        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+          node.set["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          server.create_data_bag("sensu", data_bag_item)
+        end.converge(described_recipe)
+      end
+
+      context "using upstream #{repo_designation} repo" do
+        it "creates sensu-enterprise apt #{repo_designation} repository definition" do
+          expect(chef_run).to add_apt_repository("sensu-enterprise").with(
+            :uri => "http://chefspec:moartests!@enterprise.sensuapp.com/apt",
+            :key => "http://chefspec:moartests!@enterprise.sensuapp.com/apt/pubkey.gpg",
+            :distribution => "sensu-enterprise",
+            :components => repo_designation == "unstable" ?  ["unstable"] : ["main"]
+          )
+        end
+      end
+
+      context "using custom host with #{repo_designation} repo" do
+        before do
+          chef_run.node.set["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.converge(described_recipe)
+        end
+
+        it "creates sensu-enterprise yum #{repo_designation} repository definition using custom repo host" do
+          expect(chef_run).to add_apt_repository("sensu-enterprise").with(
+            :uri => "http://chefspec:moartests!@chefspec.example.com/apt",
+            :key => "http://chefspec:moartests!@chefspec.example.com/apt/pubkey.gpg",
+            :distribution => "sensu-enterprise",
+            :components => repo_designation == "unstable" ?  ["unstable"] : ["main"]
+          )
+        end
+      end
+    end
+
+    context "yum platforms" do
+
+      let(:chef_run) do
+        ChefSpec::ServerRunner.new(:platform => "centos", :version => "6.6") do |node, server|
+          node.set["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          server.create_data_bag("sensu", data_bag_item)
+        end.converge(described_recipe)
+      end
+
+      let(:yum_repo_designation) { repo_designation == "unstable" ? "yum-unstable" : "yum" }
+
+      context "using upstream #{repo_designation} repo" do
+        it "creates sensu-enterprise yum #{repo_designation} repository definition" do
+          expect(chef_run).to add_yum_repository("sensu-enterprise").with(
+            :url => "http://chefspec:moartests!@enterprise.sensuapp.com/#{yum_repo_designation}/noarch/",
+            :gpgcheck => false
+          )
+        end
+      end
+
+      context "using custom host with #{repo_designation} repo" do
+        before do
+          chef_run.node.set["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.converge(described_recipe)
+        end
+
+        it "creates sensu-enterprise yum #{repo_designation} repository definition using custom repo host" do
+          expect(chef_run).to add_yum_repository("sensu-enterprise").with(
+            :url => "http://chefspec:moartests!@chefspec.example.com/#{yum_repo_designation}/noarch/",
+            :gpgcheck => false
+          )
+        end
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Description
* Adding attributes for configuring repository host, protocol
* Isolate Enterprise repo configuration into a new shared recipe (`sensu::_enterprise_repo`)

## Motivation and Context
Closes #437

## How Has This Been Tested?

I've added unit tests for the new `sensu::_enterprise_repo` and successfully tested the changes via `bundle exec kitchen test enterprise`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.