### PR TITLE
Enhance validation of sensu_check resources

### DIFF
--- a/resources/check.rb
+++ b/resources/check.rb
@@ -23,6 +23,8 @@ end
 
 def after_created
   unless name =~ /^[\w\.-]+$/
-    raise Chef::Exceptions::ValidationFailed, "Sensu check name cannot contain spaces or special characters"
+    raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: name cannot contain spaces or special characters"
   end
+
+  raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: must either define subscribers, or has to be standalone." unless (subscribers || standalone)
 end

--- a/test/cookbooks/sensu-test/recipes/bad_check_attributes.rb
+++ b/test/cookbooks/sensu-test/recipes/bad_check_attributes.rb
@@ -1,0 +1,4 @@
+sensu_check "invalid_check_attributes" do
+  interval 20
+  command 'true'
+end

--- a/test/cookbooks/sensu-test/recipes/bad_check_name.rb
+++ b/test/cookbooks/sensu-test/recipes/bad_check_name.rb
@@ -1,0 +1,5 @@
+sensu_check "this will fail name validation" do
+  interval 20
+  command 'true'
+  standalone true
+end

--- a/test/cookbooks/sensu-test/recipes/good_checks.rb
+++ b/test/cookbooks/sensu-test/recipes/good_checks.rb
@@ -1,0 +1,12 @@
+
+sensu_check "valid_standalone_check" do
+  interval 20
+  command 'true'
+  standalone true
+end
+
+sensu_check "valid_pubsub_check" do
+  interval 20
+  command 'true'
+  subscribers ['all']
+end

--- a/test/unit/check_spec.rb
+++ b/test/unit/check_spec.rb
@@ -1,0 +1,30 @@
+require_relative 'spec_helper'
+
+describe 'sensu-test::good_checks' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it "creates valid_standalone_check sensu_check" do
+    expect(chef_run).to create_sensu_check("valid_standalone_check").with(:standalone => true)
+  end
+
+  it "creates valid_pubsub_check sensu_check" do
+    expect(chef_run).to create_sensu_check("valid_pubsub_check").with(:subscribers => ['all'])
+  end
+
+end
+
+describe 'sensu-test::bad_check_name' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it "raises an exception when the check name contains invalid characters" do
+    expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+end
+
+describe 'sensu-test::bad_check_attributes' do
+  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+
+  it "raises an exception when the check has neither subscribers nor standalone attributes" do
+    expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
+  end
+end


### PR DESCRIPTION
## Description
Cherry-picked from #396, closes #396

* Adds validation of check names
* Ensures presense of `standalone` or `subscribers` attributes

## Motivation and Context

The current implementation of the `sensu_check` resource provider may create invalid check configurations, e.g. checks with names which include spaces, or that lack required attributes. In some cases these invalid check configurations will cause Sensu services to fail on startup.

These changes were offered in #396 which was opened against master branch. This PR seeks to apply the same changes against the development branch in a more concise way.

## How Has This Been Tested?

Added unit tests and recipes in `sensu-test` cookbook fixture to support this extended validation of sensu_check resources. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.