### PR TITLE
update nellie config to run apt-get update before installing packages

### DIFF
--- a/.nellie
+++ b/.nellie
@@ -1,5 +1,6 @@
 {
     "commands": [
+        "apt-get update",
         "apt-get install -y libxml2-dev libxslt-dev zlib1g-dev",
         "bundle install --without integration",
         "bundle exec rake"


### PR DESCRIPTION
## Description

Updates automated testing steps to ensure `apt-get update` is run before attempting to install packages.

## Motivation and Context

We are experiencing intermittent execution failures with Nellie, hoping adding this step will help us narrow down the scope of the issue.

## How Has This Been Tested?

This PR is its own test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
