### PR TITLE
Codecoverage report and 14.04 tests for client

### DIFF
--- a/test/unit/client_service_spec.rb
+++ b/test/unit/client_service_spec.rb
@@ -10,11 +10,30 @@ describe "sensu::client_service" do
     end.converge(described_recipe)
   end
 
-  it "enables the sensu-client service" do
+  it "enables the sensu-client service in ubuntu 12.04" do
     expect(chef_run).to enable_sensu_service("sensu-client")
   end
 
-  it "starts the sensu-client service" do
+  it "starts the sensu-client service in ubuntu 12.04" do
+    expect(chef_run).to start_sensu_service("sensu-client")
+  end
+end
+
+describe "sensu::client_service" do
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "14.04") do |node, server|
+      # allow(node).to receive(:chef_environment).and_return(env.name)
+      # server.create_environment(env.name, { description: "an environment for unit tests" })
+      # server.create_data_bag("sensu", sensu_data_bag)
+      # server.create_node(rabbitmq_node_name, rabbitmq_node_attrs)
+    end.converge(described_recipe)
+  end
+
+  it "enables the sensu-client service in ubuntu 14.04" do
+    expect(chef_run).to enable_sensu_service("sensu-client")
+  end
+
+  it "starts the sensu-client service in ubuntu 14.04" do
     expect(chef_run).to start_sensu_service("sensu-client")
   end
 end

--- a/test/unit/common_examples.rb
+++ b/test/unit/common_examples.rb
@@ -38,7 +38,7 @@ RSpec.shared_examples 'sensu default recipe' do
       chef_run.node.set["sensu"]["use_ssl"] = false
       chef_run.converge(described_recipe)
     end
-    
+
     it "does not write the certificate chain file" do
       expect(chef_run).to_not create_file(ssl_cert_chain_file)
     end

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'chefspec'
 require 'chefspec/librarian'
 
+ChefSpec::Coverage.start!
+
 RSpec.shared_context('sensu data bags') do
   let(:ssl_data_bag_item) do
     # JSON.parse(


### PR DESCRIPTION
Added the Chefspec built in code coverage report and tests for client for 14.04.


## Motivation and Context
You were only testing 12.04 in your unit tests, this now covers 14.04

## How Has This Been Tested?
It is a test ;)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
