### PR TITLE
Adding a name attribute for transport

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default["sensu"]["add_repo"] = true
 
 # transport
 default["sensu"]["transport"]["reconnect_on_error"] = true
+default["sensu"]["transport"]["name"] = 'rabbitmq'
 
 # rabbitmq
 default["sensu"]["rabbitmq"]["host"] = "localhost"


### PR DESCRIPTION
This provides a nice hint that the transport can be changed if needed.  Useful when end users plan on using redis for their queues.