### PR TITLE
Exclude feature which only exists for Windows 2012 to fix Windows 2008 client installs

### DIFF
--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -37,10 +37,9 @@ if win_version.windows_server_2012? || win_version.windows_server_2012_r2?
   windows_feature "NetFx3ServerFeatures" do
     source node["sensu"]["windows"]["dism_source"]
   end
-end
-
-windows_feature "NetFx3" do
-  source node["sensu"]["windows"]["dism_source"]
+  windows_feature "NetFx3" do
+    source node["sensu"]["windows"]["dism_source"]
+  end
 end
 
 windows_package "Sensu" do


### PR DESCRIPTION
### Exclude a windows feature which only exists on windows 2012.

Running the standard cookbook on a windows 2008 server will run the following command:
C:\Windows\system32\servermanagercmd.exe -install NetFx3 
This results in an error.

If you log into any 2008 system and run the query command -
C:\Windows\system32\servermanagercmd.exe -install NetFx3 
or look at the documentation - 
https://technet.microsoft.com/en-us/library/cc748918%28v=ws.10%29.aspx
You will see the issue.
There is no 'NetFx3' feature in 2008.
The 'NetFx3' feature only exists in 2012 and installs the .net 2.0 and 3.0 frameworks.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.