### PR TITLE
Make .Net Framework installation optional, "outsource" it to ms_dotnet cookbook

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -14,15 +14,29 @@ platforms:
   - name: centos-6.5
     driver:
       box: opscode-centos-6.5
+  - name: windows-2008-r2
+    transport:
+      name: winrm
+      elevated: true
+    driver:
+      http_proxy: null
+      https_proxy: null
+      box: windows-2008r2
+      customize:
+        memory: 2048
+    attributes:
+      lsb:
+        codename: windows
   - name: windows-2012-r2
-    provisioner:
-      name: chef_zero_scheduled_task
+    transport:
+      name: winrm
+      elevated: true
     driver:
       http_proxy: null
       https_proxy: null
       box: windows-2012r2
-      customize:
-        memory: 2048
+    customize:
+      memory: 2048
     attributes:
       lsb:
         codename: windows
@@ -35,8 +49,6 @@ suites:
     attributes:
       sensu:
         group: nogroup
-        windows:
-          dism_source: <%= ENV['SENSU_WINDOWS_DISM_SOURCE'] %>
   - name: sysv
     run_list:
       - recipe[sensu-test]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -53,6 +53,7 @@ suites:
     run_list:
       - recipe[sensu-test]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
       - centos-5.11
       - centos-6.5
@@ -60,11 +61,13 @@ suites:
     run_list:
       - recipe[sensu-test::runit]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
   - name: encrypted
     run_list:
       - recipe[sensu-test]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
   - name: acls
     run_list:
@@ -80,6 +83,7 @@ suites:
     run_list:
       - recipe[sensu-test]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
       - centos-5.11
     attributes:
@@ -98,6 +102,7 @@ suites:
     run_list:
       - recipe[sensu-test::enterprise]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
   - name: enterprise-dashboard
     attributes:
@@ -107,9 +112,11 @@ suites:
     run_list:
       - recipe[sensu-test::enterprise_dashboard]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
   - name: run-state-helpers
     run_list:
       - recipe[sensu-test::run_state_helpers]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2

--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,10 @@ group :develop do
 end
 
 group :integration do
-  gem "chef-zero-scheduled-task", "~> 0.1"
-  gem "test-kitchen", "~> 1.7"
+  gem "test-kitchen", "~> 1.8"
   gem "kitchen-docker"
   gem "kitchen-vagrant"
   gem "winrm-fs"
   gem "winrm-transport"
+  gem "winrm-elevated"
 end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See CODE_OF_CONDUCT.md, CONTRIBUTING.md and TESTING.md documents.
 * [Windows](http://community.opscode.com/cookbooks/windows)
 * [RabbitMQ](http://community.opscode.com/cookbooks/rabbitmq)
 * [RedisIO](http://community.opscode.com/cookbooks/redisio)
+* [ms_dotnet](http://community.opscode.com/cookbooks/ms_dotnet)
 
 NOTE: This cookbook either constrains its dependencies optimistically (`>=`) or not at all. You're strongly encouraged to more strictly manage these dependencies in your wrapper cookbook.
 
@@ -162,6 +163,16 @@ Sensu services, "sysv" and "runit" are currently supported.
 
 `node["sensu"]["service_max_wait"]` - How long service scripts should wait
 for Sensu to start/stop.
+
+### Windows
+
+Sensu requires Microsoft's .Net Framework to run on Windows. The following attributes influence the installation of .Net via this cookbook:
+
+`node["sensu"]["windows"]["install_dotnet"]` - Toggles installation of .Net Framework using ms_dotnet cookbook. (default: true)
+
+`node["sensu"]["windows"]["dotnet_major_version"]` - Major version of .Net Framework to install. (default: 4)
+
+Adjusting the value of `dotnet_major_version` attribute will influence which recipe from `ms_dotnet` cookbook will be included. See [`ms_dotnet` cookbook documentation](https://github.com/criteo-cookbooks/ms_dotnet/blob/v2.6.1/README.md) for additional details on using this cookbook.
 
 ### Transport
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,8 +7,9 @@ if platform_family?("windows")
   default["sensu"]["admin_user"] = "Administrator"
   default["sensu"]["directory"] = 'C:\etc\sensu'
   default["sensu"]["log_directory"] = 'C:\var\log\sensu'
-  default["sensu"]["windows"]["dism_source"] = nil
   default["sensu"]["windows"]["package_options"] = nil
+  default["sensu"]["windows"]["install_dotnet"] = true
+  default["sensu"]["windows"]["dotnet_major_version"] = 4
 else
   default["sensu"]["admin_user"] = "root"
   default["sensu"]["directory"] = "/etc/sensu"

--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -94,6 +94,38 @@ module Sensu
         end
         password
       end
+
+      # Wraps the Chef::Util::Windows::NetUser, returning false if the Win32 constant
+      # is undefined, or returning false if the user does not exist. This indirection
+      # seems like the most expedient way to make the sensu::_windows recipe testable
+      # via chefspec on non-windows platforms.
+      #
+      # @param [String] the name of the user to test for
+      # @return [TrueClass, FalseClass]
+      def windows_user_exists?(user)
+        if defined?(Win32)
+          net_user = Chef::Util::Windows::NetUser.new(user)
+          !!net_user.get_info rescue false
+        else
+          false
+        end
+      end
+
+      # Wraps Win32::Service, returning false if the Win32 constant
+      # is undefined, or returning false if the user does not exist. This indirection
+      # seems like the most expedient way to make the sensu::_windows recipe testable
+      # via chefspec on non-windows platforms.
+      #
+      # @param [String] the name of the service to test for
+      # @return [TrueClass, FalseClass]
+      def windows_service_exists?(service)
+        if defined?(Win32)
+          ::Win32::Service.exists?(service)
+        else
+          false
+        end
+      end
+
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -15,6 +15,9 @@ depends "yum"
 # available @ http://supermarket.chef.io/cookbooks/windows
 depends "windows", ">= 1.8.8"
 
+# available @ https://supermarket.chef.io/cookbooks/ms_dotnet
+depends "ms_dotnet", ">= 2.6.1"
+
 # available @ http://supermarket.chef.io/cookbooks/rabbitmq
 depends "rabbitmq", ">= 2.0.0"
 

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -30,13 +30,13 @@ group "sensu" do
 end
 
 if windows["install_dotnet"]
-  include_recipe "ms_dotnet::ms_dotnet#{windows["dotnet_major_version"]}"
+  include_recipe "ms_dotnet::ms_dotnet#{windows['dotnet_major_version']}"
 end
 
 windows_package "Sensu" do
   source "#{node['sensu']['msi_repo_url']}/sensu-#{node['sensu']['version']}.msi"
   options windows["package_options"]
-  version node["sensu"]["version"].gsub("-", ".")
+  version node["sensu"]["version"].tr("-", ".")
   notifies :create, "ruby_block[sensu_service_trigger]", :immediately
 end
 
@@ -48,7 +48,5 @@ end
 
 execute "sensu-client.exe install" do
   cwd 'C:\opt\sensu\bin'
-  not_if {
-     Sensu::Helpers.windows_service_exists?("sensu-client")
-  }
+  not_if { Sensu::Helpers.windows_service_exists?("sensu-client") }
 end


### PR DESCRIPTION
## Description

This PR proposes the following changes:

* Add dependency on `ms_dotnet` cookbook
* Make installation of .Net Framework optional, controlled by new `node["sensu"]["windows"]["install_dotnet"]` attribute.
* Use value of new `node["sensu"]["windows"]["dotnet_major_version"]` for determining which recipe to include from `ms_dotnet` cookbook
* Add windows-2008r2 to test-kitchen platforms
* Update test-kitchen and add gems to support use of [WinRM elevated transport](https://github.com/test-kitchen/test-kitchen/pull/1012)
* Add indirection helper methods around Windows-specific modules to make ChefSpec testing more straight-forward. Without these methods we have to use Rspec stubs on the include_recipe, which makes testing some things much more difficult.

## Motivation and Context

As described in https://github.com/sensu/sensu-chef/issues/423#issuecomment-193914272, I believe it is desirable to make .Net Framework installation optional, and to "outsource" the installation to another cookbook which is responsible for the isolated logic of that operation.

## How Has This Been Tested?

The `default` suite is passing on both windows-2008r2 and windows-2012r2 in my local test-kitchen environment. Unit tests are also passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.