### PR TITLE
Add guard, rubocop and foodcritic to bundle

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,18 @@
+Encoding:
+  Enabled: false
+
+LineLength:
+  Max: 200
+
+StringLiterals:
+  Enabled: false
+
+Style/HashSyntax:
+  EnforcedStyle: hash_rockets
+
+AllCops:
+  Exclude:
+    - 'Guardfile'
+    - 'tmp/**/*'
+    - 'cookbooks/**/*'
+    - 'test/cookbooks/**/files/**/*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2
+  - 2.2.5
 before_install: gem install bundler -v 1.10.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,20 @@
 source "https://rubygems.org"
 
+group :lint do
+  gem 'foodcritic', '~> 6.0'
+  gem 'rubocop', '~> 0.39.0'
+end
+
 group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
   gem "emeril", "~> 0.8"
   gem "librarian-chef"
   gem "rake"
+  gem "guard"
+  gem "guard-foodcritic"
+  gem "guard-rspec"
+  gem "guard-rubocop"
 end
 
 group :integration do

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,39 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+# guard 'kitchen' do
+#   watch(%r{test/.+})
+#   watch(%r{^recipes/(.+)\.rb$})
+#   watch(%r{^attributes/(.+)\.rb$})
+#   watch(%r{^files/(.+)})
+#   watch(%r{^templates/(.+)})
+#   watch(%r{^providers/(.+)\.rb})
+#   watch(%r{^resources/(.+)\.rb})
+# end
+
+# rubocop:disable all
+
+guard 'foodcritic', :cookbook_paths => '.', :all_on_start => false do
+  watch(%r{attributes/.+\.rb$})
+  watch(%r{providers/.+\.rb$})
+  watch(%r{recipes/.+\.rb$})
+  watch(%r{resources/.+\.rb$})
+  watch('metadata.rb')
+end
+
+guard 'rubocop', :all_on_start => false do
+  watch(%r{attributes/.+\.rb$})
+  watch(%r{providers/.+\.rb$})
+  watch(%r{recipes/.+\.rb$})
+  watch(%r{resources/.+\.rb$})
+  watch('metadata.rb')
+end
+
+guard :rspec, :cmd => 'bundle exec rspec', :all_on_start => false, :notification => false, :spec_paths => [ 'test/unit' ] do
+  watch(%r{^libraries/(.+)\.rb$})   { |m| "test/unit/libraries/#{m[1]}_spec.rb" }
+  watch(%r{^providers/(.+)\.rb$})   { |m| "test/unit/lwrps/#{m[1]}_spec.rb" }
+  watch(%r{^resources/(.+)\.rb$})   { |m| "test/unit/lwrps/#{m[1]}_spec.rb" }
+  watch(%r{^test/unit/(.+)_spec\.rb$})
+  watch(%r{^(recipes)/(.+)\.rb$})   { |m| "test/unit/#{m[1]}_spec.rb" }
+  watch('test/unit/spec_helper.rb') { 'spec' }
+end

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 ## Testing the cookbook
 
-This cookbook has tests in the source repository. To run the tests:
+This cookbook has tests in the source repository. To run the tests, first install the required gems:
 
 ```
 git clone git://github.com/sensu/sensu-chef.git
@@ -12,7 +12,7 @@ There are two kinds of tests in use: unit and integration tests.
 
 ### Unit Tests
 
-The resource/provider code is unit tested with rspec. To run these tests, use rake:
+The cookbook is unit tested with rspec. To run these tests, use rake:
 
 ```
 bundle exec rake spec
@@ -27,6 +27,10 @@ bundle exec rake kitchen:all
 ```
 
 This tests a number of different suites, some of which require special credentials or virtual machine configurations. Please see the caveats and known issues below for additional details.
+
+### Local development tools
+
+The project includes tools like Rubocop and Foodcritic to help with uniformity and quality of code changes. Because these tools presently report a number of existing violations, they are not enabled as part of our automatic testing as of this writing. During local development it is recommended that you run `bundle exec guard` to automatically test your changes using these tools.
 
 ### Caveats and known issues
 


### PR DESCRIPTION
## Description
Adds the following tools in the interest of improving code quality/uniformity:

* Rubocop
* Foodcritic
* Guard (runs Rubocop and Foodcritic when files change)

## Motivation and Context
This cookbook currently lacks style and linting checks. This change adds some tools and rules for using them, but because of the large number of existing failures, does not add them to the automatic tests run by Travis CI. 

## How Has This Been Tested?
The tools added in this PR can be used during local development by running `bundle exec guard`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
