### PR TITLE
Add attribute to support JAVA_OPTS to defaults file

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,18 @@ for Sensu to start/stop.
 ### Sensu Enterprise
 
 `node["sensu"]["enterprise"]["repo_protocol"]` - Sensu Enterprise repo protocol (e.g. http, https)
+
 `node["sensu"]["enterprise"]["repo_host"]` - Sensu Enterprise repo host
+
 `node["sensu"]["enterprise"]["version"]` - Desired Sensu Enterprise package version
+
 `node["sensu"]["enterprise"]["use_unstable_repo"]` - Toggle use of Sensu Enterprise unstable repository
+
 `node["sensu"]["enterprise"]["log_level"]` - Configure Sensu Enterprise log level
+
 `node["sensu"]["enterprise"]["heap_size"]` - Configure Sensu Enterprise heap size
+
+`node["sensu"]["enterprise"]["java_opts"]` - Specify additional Java options when running Sensu Enterprise
 
 ## LWRP'S
 

--- a/attributes/enterprise.rb
+++ b/attributes/enterprise.rb
@@ -5,3 +5,4 @@ default["sensu"]["enterprise"]["version"] = "1.5.2-1"
 default["sensu"]["enterprise"]["use_unstable_repo"] = false
 default["sensu"]["enterprise"]["log_level"] = "info"
 default["sensu"]["enterprise"]["heap_size"] = "2048m"
+default["sensu"]["enterprise"]["java_opts"] = ""

--- a/templates/default/sensu-enterprise.default.erb
+++ b/templates/default/sensu-enterprise.default.erb
@@ -3,3 +3,4 @@ CONFIG_DIR=/etc/sensu/conf.d
 PLUGINS_DIR=/etc/sensu/plugins
 LOG_LEVEL=<%= node["sensu"]["enterprise"]["log_level"] %>
 HEAP_SIZE="<%= node["sensu"]["enterprise"]["heap_size"] %>"
+JAVA_OPTS="<%= node["sensu"]["enterprise"]["java_opts"] %>"


### PR DESCRIPTION
The changes add an attribute to the enterprise hash to support adding the JAVA_OPTS value to the defaults file. This value is used to add additional options to the JRE invocation during sensu-enterprise startup. 

## Description
* Added an entry to the *templates/default/sensu-enterprise.default.erb* file for the `JAVA_OPTS` value. 
* Added a default attribute for `["sensu"]["enterprise"]["java_opts"]` set to an empty string
* Updated the README to reference attribute and fix formatting. 

## Motivation and Context
We needed to add the ability to add an option, `-javaagent` to the JVM so we can use Jolokia to track settings. There was no easy way to do this because the file would be overwritten on subsequent chef convergences. 

## How Has This Been Tested?
Tested kitchen builds to ensure changes did not cause issues. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
