### PR TITLE
Change aggregate to string & bump default version

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@ else
 end
 
 # installation
-default["sensu"]["version"] = "0.23.1-1"
+default["sensu"]["version"] = "0.25.1-1"
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -14,8 +14,8 @@ action :create do
   check = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type command timeout subscribers standalone aggregate handle handlers
-      publish subdue low_flap_threshold high_flap_threshold
+      type command timeout subscribers standalone aggregate aggregates handle
+      handlers publish subdue low_flap_threshold high_flap_threshold
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -6,7 +6,7 @@ attribute :command, :kind_of => String, :required => true
 attribute :timeout, :kind_of => Integer
 attribute :subscribers, :kind_of => Array
 attribute :standalone, :kind_of => [TrueClass, FalseClass]
-attribute :aggregate, :kind_of => String
+attribute :aggregate, :kind_of => [String, TrueClass, FalseClass]
 attribute :aggregates, :kind_of => Array
 attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -6,7 +6,7 @@ attribute :command, :kind_of => String, :required => true
 attribute :timeout, :kind_of => Integer
 attribute :subscribers, :kind_of => Array
 attribute :standalone, :kind_of => [TrueClass, FalseClass]
-attribute :aggregate, :kind_of => [TrueClass, FalseClass]
+attribute :aggregate, :kind_of => String
 attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -7,6 +7,7 @@ attribute :timeout, :kind_of => Integer
 attribute :subscribers, :kind_of => Array
 attribute :standalone, :kind_of => [TrueClass, FalseClass]
 attribute :aggregate, :kind_of => String
+attribute :aggregates, :kind_of => Array
 attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array


### PR DESCRIPTION
Updated the aggregate attribute type to a String to accommodate named aggregates as per https://sensuapp.org/docs/0.25/reference/aggregates.html 

## Description
As of 0.24 aggregate definitions can now be strings rather than Boolean values, the chef check resource required updating to reflect this.

Default version has also been bumped up to 0.25.1-1.

## Motivation and Context
Using the sensu_check resource on 0.25 currently does not work for named aggregates

## How Has This Been Tested?
Tested locally using Kitchen

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document.
