### PR TITLE
fix CHEF-3694 warnings when calling rabbitmq_credentials

### DIFF
--- a/definitions/rabbitmq_credentials.rb
+++ b/definitions/rabbitmq_credentials.rb
@@ -1,16 +1,16 @@
 define :rabbitmq_credentials do
-  rabbitmq_vhost params[:vhost] do
-    action :add
-  end
+  unless get_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], key)
+    rabbitmq_vhost params[:vhost] do
+      action :add
+    end
 
-  rabbitmq_user params[:user] do
-    password params[:password]
-    action :add
-  end
+    rabbitmq_user params[:user] do
+      password params[:password]
+      vhost params[:vhost]
+      permissions params[:permissions] || ".* .* .*"
+      action [:add, :set_permissions]
+    end
 
-  rabbitmq_user params[:user] do
-    vhost params[:vhost]
-    permissions params[:permissions] || ".* .* .*"
-    action :set_permissions
+    set_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], key, true)
   end
 end


### PR DESCRIPTION
This patch fixes harmless warnings about cloning resource attributes. This happens mostly during testing a cookbook, which uses sensu cookbook as a dependency.

## Description
rabbitmq_credential won't trigger rabbitmq_vhost and rabbitmq_user if that user/vhost combo has been created already. It also "fixes" the warning due to calling rabbitmq_user for both user creation (action :add) and permission changes (action :set_permission). It doesn't cause any behavioral change, except in the case of calling rabbitmq_credentials multiple times with different passwords or permissions, but with the same username and vhost. This would be a misuse of the resource though.

## Motivation and Context
The resulting error makes a lot of unnecessary output while developing cookbooks depending on this one. Fixes #355 and parts of #462.

## How Has This Been Tested?
Unit tests passed. No extra tests have been written, as problems happen outside of the scope of this cookbook, in other cookbooks' test runs.

Tested with a cookbook depending on this one. Not tested with the sample monitoring cookbook though.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
