### PR TITLE
Fixes the code to find sensu_service_trigger in resource collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Enables and starts Sensu Enterprise Dashboard.
 Default "sensu".
 
 `node["sensu"]["use_embedded_ruby"]` - If Sensu Ruby handlers and plugins
-use the embedded Ruby in the Sensu package (default: false).
+use the embedded Ruby in the Sensu package (default: true).
 
 `node["sensu"]["init_style"]` - Style of init to be used when configuring
 Sensu services, "sysv" and "runit" are currently supported.

--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -1,5 +1,5 @@
 action :create do
-  sensu_service_trigger = !!node.run_context.resource_collection.detect do |r|
+  sensu_service_trigger = !!run_context.resource_collection.detect do |r|
     r.to_s == "ruby_block[sensu_service_trigger]"
   end
 


### PR DESCRIPTION
## Description
The json_file provider looks up if there is a ruby_block resource called sensu_service_trigger in the resource collection. However, even if the resource was in collection, it failed to find it. This commit removes the node prefix from the statement that looks for the resource and now it can find the ruby_block['sensu_service_trigger'] when it is defined

And it also updates README with the fact that using embedded ruby has been made true as default

## Motivation and Context
Problem: The json_file provider looks up if there is a ruby_block resource called sensu_service_trigger in the resource collection. However, even if the resource was in collection, it failed to find it. So even if a check is updated (which uses the json_file resource), the sensu_service_trigger was not notified and the sensu-server was not restarted.

Solution: This commit removes the node prefix from the statement that looks for the resource and now it can find the ruby_block['sensu_service_trigger'] when it is defined. As a result, whenever a check is updated, the sensu server gets restarted

## How Has This Been Tested?
tested with Chef 12.3.0 on a CentOS 6.6 vagrant box. Tested when a check changes, it restarts the sensu-server, when no change, it does not. Also tested when the resource ruby_block['sensu_service_trigger'] is not defined, it does not attempt to notify it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
