### PR TITLE
update gem_lwrp test recipe to use a gem with fewer dependencies

### DIFF
--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -19,15 +19,15 @@ sensu_gem 'sensu-plugins-hipchat' do
   action :remove
 end
 
-cpu_checks = ::File.join(Chef::Config[:file_cache_path], 'sensu-plugins-cpu-checks.gem')
+mem_checks = ::File.join(Chef::Config[:file_cache_path], 'sensu-plugins-memory-checks.gem')
 
-remote_file cpu_checks do
-  source 'https://rubygems.org/downloads/sensu-plugins-cpu-checks-0.0.3.gem'
+remote_file mem_checks do
+  source 'https://rubygems.org/downloads/sensu-plugins-memory-checks-1.0.2.gem'
 end
 
 # for testing source property
-sensu_gem 'sensu-plugins-cpu-checks' do
-  source cpu_checks
+sensu_gem 'sensu-plugins-memory-checks' do
+  source mem_checks
   action :install
 end
 

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -25,7 +25,7 @@ describe 'sensu_gem' do
 
     context 'source specified' do
       it 'installs the specified gem package from the specified source' do
-        expect(chef_run).to install_gem_package('sensu-plugins-cpu-checks').with(:source => '/tmp/sensu-plugins-cpu-checks.gem')
+        expect(chef_run).to install_gem_package('sensu-plugins-memory-checks').with(:source => '/tmp/sensu-plugins-memory-checks.gem')
       end
     end
   end


### PR DESCRIPTION
## Description

Modify gem_lwrp tests to use sensu-plugins-memory-checks in lieu of sensu-plugin-cpu-checks

## Motivation and Context
Integration tests installing sensu-plugin-cpu-checks are failing for me due to a broken dependency on linux-kstat

sensu-plugins-memory-checks has no dependencies aside from sensu-plugin 👍

## How Has This Been Tested?

tested in test-kitchen

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.