### PR TITLE
adding ability to cleanup checks that are not managed by chef.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -120,3 +120,17 @@ suites:
     excludes:
       - windows-2008-r2
       - windows-2012-r2
+  - name: cleanup
+    driver:
+      name: vagrant
+      provision: true
+      vagrantfiles:
+        - test/files/vagrant.check-to-remove.rb
+    run_list:
+      - recipe[sensu-test]
+      - recipe[sensu-test::cleanup_checks]
+    excludes:
+      - windows-2008-r2
+      - windows-2012-r2
+      - centos-5.11
+      - centos-6.5

--- a/README.md
+++ b/README.md
@@ -281,6 +281,14 @@ sensu_snippet "irc" do
 end
 ```
 
+### Clean up checks that are no longer managed by chef
+
+```ruby
+sensu_cleanup ::File.join(node.sensu.directory, "conf.d", "checks") do
+  notifies :create, "ruby_block[sensu_service_trigger]", :delayed
+end
+```
+
 ## Helper modules and methods
 
 ### Run State Helpers

--- a/providers/cleanup_checks.rb
+++ b/providers/cleanup_checks.rb
@@ -1,0 +1,29 @@
+action :run do
+  Chef::Log.info "any checks in #{new_resource.path} that are not managed by chef will be removed"
+
+  file_list = ::Dir.glob(::File.join(new_resource.path, '*.json'))
+
+  protected_files = []
+  run_context.resource_collection.all_resources.select do |resource|
+    if resource.resource_name.to_s.include? 'sensu_check'
+      protected_files << ::File.join(new_resource.path, "#{resource.name}.json")
+    end
+  end
+
+  Chef::Log.info "Protected Files: #{protected_files}"
+
+  checks_to_remove = file_list - protected_files
+
+  checks_to_remove.each do |f|
+    Chef::Log.info("Sensu check '#{f}' is not managed by Chef. Removing it.")
+    file f do
+      action :delete
+    end
+  end
+
+  new_resource.updated_by_last_action(true) unless checks_to_remove.empty?
+end
+
+action :disable do
+  Chef::Log.info("all checks in #{new_resource.path} will be left as is!!!!")
+end

--- a/resources/cleanup_checks.rb
+++ b/resources/cleanup_checks.rb
@@ -1,0 +1,5 @@
+actions :run, :disable
+
+default_action :run
+
+attribute :path, :kind_of => String, :name_attribute => true

--- a/test/cookbooks/sensu-test/recipes/cleanup_checks.rb
+++ b/test/cookbooks/sensu-test/recipes/cleanup_checks.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: sensu-test
+# Recipe:: cleanup_checks
+#
+# Copyright 2013, Sonian, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+sensu_cleanup_checks ::File.join(node.sensu.directory, "conf.d", "checks") do
+  notifies :create, "ruby_block[sensu_service_trigger]", :delayed
+end

--- a/test/files/vagrant.check-to-remove.rb
+++ b/test/files/vagrant.check-to-remove.rb
@@ -1,0 +1,8 @@
+$script = <<SCRIPT
+mkdir -p /etc/sensu/conf.d/checks
+echo '{"checks": {"check_to_be_removed": { "command": "true", "subscribers": [ "all" ], "interval": 20 } } }' > /etc/sensu/conf.d/checks/check_to_be_removed.json
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.provision 'shell', inline: $script, privileged: true
+end

--- a/test/integration/cleanup/serverspec/cleanup_check_spec.rb
+++ b/test/integration/cleanup/serverspec/cleanup_check_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe file('/etc/sensu/conf.d/checks/check_to_be_removed.json') do
+  it { should_not exist }
+end
+
+# ensure that we did not remove any checks that still have chef resources for
+describe file('/etc/sensu/conf.d/checks/test.json') do
+  it { should exist }
+end


### PR DESCRIPTION
## Description
Adding the ability to have chef remove any changes that are no longer (or never were) managed by chef.

## Motivation and Context
When you remove a chef resource that you use to create a sensu check the file still stays locally and therefore the check is not removed.
moving this work across the line: https://github.com/sensu/sensu-chef/pull/288

## How Has This Been Tested?
Using a custom vagrantfile to create a test check outside of the scope of chef and using serverspec to verify the file does not exist after running the lwrp as well as ensuring that checks managed by chef persisted.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

Disclaimer: all the original work was proposed by someone else and I am just trying to get it across the line. see the original PR: https://github.com/sensu/sensu-chef/pull/288