### PR TITLE
Ensure sensu_json_file uses directory_mode attribute when creating directory

### DIFF
--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -8,7 +8,7 @@ action :create do
       recursive true
       owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
       group lazy { new_resource.group || node["sensu"]["group"] }
-      mode 0750
+      mode lazy { node["sensu"]["directory_mode"] }
     end
 
     f = file new_resource.path do

--- a/test/cookbooks/sensu-test/recipes/json_file.rb
+++ b/test/cookbooks/sensu-test/recipes/json_file.rb
@@ -1,0 +1,5 @@
+foo = { :lol => "wtfbbq" }
+
+sensu_json_file '/etc/sensu/foo.json' do
+  content foo
+end

--- a/test/unit/lwrps/json_file_spec.rb
+++ b/test/unit/lwrps/json_file_spec.rb
@@ -1,0 +1,20 @@
+require_relative "../spec_helper"
+
+describe 'sensu_json_file' do
+
+  let(:test_directory_mode) { "0755" }
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      :step_into => ['sensu_json_file'],
+      :file_cache_path => '/tmp'
+    ) do |node|
+      node.set['sensu']['directory_mode'] = test_directory_mode
+    end.converge('sensu-test::json_file')
+  end
+
+  it 'creates the /etc/sensu directory using value of directory_mode attribute' do
+    expect(chef_run).to create_directory('/etc/sensu').with({ :mode => test_directory_mode })
+  end
+
+end


### PR DESCRIPTION
## Description

Updating the `sensu_json_file` provider to use the value of the `sensu.directory_mode` attribute instead of the static `0750` mode. I believe the default value of this attribute is a functional match for the existing static value, `"0750"` and `0750` respectively .

## Motivation and Context

As described in #451 the `sensu_json_file` provider currently creates parent directories but does not take advantage of the existing `directory_mode` attribute, making it difficult for operators to influence the directory permissions.

Closes #451 

## How Has This Been Tested?

Existing tests pass, added a unit test to cover this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.