### PR TITLE
Use Erlang Solutions (esl) repo to provide Erlang on all platforms

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,9 +11,7 @@ platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: centos-5.11
-  - name: centos-6.5
-    driver:
-      box: opscode-centos-6.5
+  - name: centos-6.7
   - name: windows-2008-r2
     transport:
       name: winrm
@@ -56,7 +54,6 @@ suites:
       - windows-2008-r2
       - windows-2012-r2
       - centos-5.11
-      - centos-6.5
   - name: runit
     run_list:
       - recipe[sensu-test::runit]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This file is used to track changes made in each version of the sensu cookbook.
 
 ## Unreleased
 
+### Important
+
+* The `rabbitmq` recipe now installs Erlang via the Erlang Solutions repository on all platforms
+
 ### Features
 
 * The `sensu_base_config` provider now honors `node["sensu"]["rabbitmq"]["hosts"]` attribute, providing an array of hosts to use for configuring rabbitmq transport with multiple brokers. When empty, falls back to existing `node["sensu"]["rabbitmq"]["host"]` attribute.

--- a/TESTING.md
+++ b/TESTING.md
@@ -34,7 +34,6 @@ The project includes tools like Rubocop and Foodcritic to help with uniformity a
 
 ### Caveats and known issues
 
-* The centos-65 platform is currently excluded from `sysv` suite, as RabbitMQ [disables SSL listeners under the currently installed version of Erlang (R14B04)](http://www.rabbitmq.com/ssl.html#old-erlang).
 * The centos-511 platform is also excluded from the `sysv` suite because the "rabbitmqctl" executable is not in root's path, which causes rabbitmq configuration to fail.
 * Testing the `enterprise` and `enterprise-dashboard` suites require valid Sensu Enterprise repository credentials exported as the values of `SENSU_ENTERPRISE_USER` and `SENSU_ENTERPRISE_PASS` respectively.
 * Testing the `enterprise` suite requires allocating ~3gb of memory to the test system.

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -73,11 +73,8 @@ if node["sensu"]["use_ssl"]
   end
 end
 
-# The packaged erlang in 12.04 (and below) is vulnerable to
-# the poodle exploit which stops rabbitmq starting its SSL listener
-if node["platform"] == "ubuntu" && node["platform_version"] <= "12.04"
-  node.override["erlang"]["install_method"] = "esl"
-end
+# Sensu recommends Erlang Solutions' erlang runtime distribution
+node.override["erlang"]["install_method"] = "esl"
 
 include_recipe "rabbitmq"
 include_recipe "rabbitmq::mgmt_console"


### PR DESCRIPTION
## Description

Historically this cookbook used the Erlang Solutions repository when installing on Ubuntu <= 12.04 as a workaround for known SSL issues. This change removes that conditional, making the Erlang Solutions repository the default method of installing Erlang using the `sensu::rabbitmq` recipe.

~~Marked as WIP while I run test-kitchen locally~~

## Motivation and Context

Closes #411 

Paid support are available for Sensu Enterprise and Sensu Core, but both offerings require use of the Erlang Solutions runtime distribution.

## How Has This Been Tested?

Local test-kitchen tests are good 👍 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

## Known Caveats

This change may cause the Erlang Solutions distribution of the erlang runtime to be installed on systems which have previously installed erlang from distribution packages.