### PR TITLE
Support multiple rabbitmq brokers via `sensu.rabbitmq.hosts` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to track changes made in each version of the sensu cookbook.
 
+## Unreleased
+
+### Features
+
+* The `sensu_base_config` provider now honors `node["sensu"]["rabbitmq"]["hosts"]` attribute, providing an array of hosts to use for configuring rabbitmq transport with multiple brokers. When empty, falls back to existing `node["sensu"]["rabbitmq"]["host"]` attribute.
+
 ## 2.12.0 - 2016-03-14
 
 ### Project changes

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Adjusting the value of `dotnet_major_version` attribute will influence which rec
 
 ### RabbitMQ
 
+`node["sensu"]["rabbitmq"]["hosts"]` - Array of RabbitMQ hosts as strings, which will be combined with other RabbitMQ attributes to generate the Sensu RabbitMQ transport configuration as an array of hashes. Falls back to `node["sensu"]["rabbitmq"]["host"]` when empty. Defaults to an empty array.
+
 `node["sensu"]["rabbitmq"]["host"]` - RabbitMQ host.
 
 `node["sensu"]["rabbitmq"]["port"]` - RabbitMQ port, usually for SSL.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -39,6 +39,7 @@ default["sensu"]["transport"]["reconnect_on_error"] = true
 default["sensu"]["transport"]["name"] = 'rabbitmq'
 
 # rabbitmq
+default["sensu"]["rabbitmq"]["hosts"] = []
 default["sensu"]["rabbitmq"]["host"] = "localhost"
 default["sensu"]["rabbitmq"]["port"] = 5671
 default["sensu"]["rabbitmq"]["vhost"] = "/sensu"


### PR DESCRIPTION
## Description
With this change we now honor an array of strings as the value of the
 `sensu.rabbitmq.hosts` attribute which, if provided, will be
combined with the other rabbitmq attributes to generate an array of rabbitmq
 transport configuration hashes.

If the `sensu.rabbitmq.hosts` array is empty (as it is by default) we will fall
back to generating an array of rabbitmq transport configuration hashes using
the value provided in `sensu.rabbitmq.host` in combination with any other
rabbitmq attributes.

## Motivation and Context
In general this cookbook passes a great deal of configuration straight through
from node attributes to JSON configuration on disk. Historically this has
included writing rabbitmq transport configuration to disk directly from
attributes as well.

Unfortunately these attributes are somewhat double-bound. They provide both
configuration for Sensu and the parameters for configuring the RabbitMQ
broker on nodes where the `sensu::rabbitmq` recipe is run. This prevents us 
from wholesale mowing over the `sensu.rabbitmq` attribute hash with an array 
of Sensu transport configuration hashes.

In Sensu 0.15 we added support for multiple rabbitmq brokers in an array,
something which users of this cookbook have heretofore had to manage using
a `sensu_snippet` resource to provide an array of rabbitmq transport
configuration hashes. In light of #363 and #461, I think its apparent that this
 approach isn't well documented nor very intuitive.

Closes #363 

## How Has This Been Tested?

Added unit tests for `sensu_base_config` provider

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

## Known Caveats

Existing configurations using a single rabbitmq broker will be rewritten to use the newer array of hashes syntax for rabbitmq transport configuration.