### PR TITLE
Extend supported sensu_client attributes to include all those defined in reference docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This file is used to track changes made in each version of the sensu cookbook.
 ### Features
 
 * The `sensu_base_config` provider now honors `node["sensu"]["rabbitmq"]["hosts"]` attribute, providing an array of hosts to use for configuring rabbitmq transport with multiple brokers. When empty, falls back to existing `node["sensu"]["rabbitmq"]["host"]` attribute.
+* The `sensu_client` provider now honors the following additional client attributes, as defined in the [Sensu Client Reference Documentation](https://sensuapp.org/docs/0.25/reference/clients.html#client-attributes):
+  * deregister
+  * deregistration
+  * keepalives
+  * redact
+  * registration
+  * safe_mode
+  * socket
 
 ## 2.12.0 - 2016-03-14
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,17 @@ sensu_client node["name"] do
 end
 ```
 
+The `sensu_client` provider also supports the following optional attributes:
+
+* deregister
+* deregistration
+* keepalive
+* keepalives
+* redact
+* registration
+* safe_mode
+* socket
+
 ### Define a handler
 
 ```ruby

--- a/providers/client.rb
+++ b/providers/client.rb
@@ -1,7 +1,33 @@
 action :create do
+  client_attrs = %w[
+    name
+    address
+    subscriptions
+  ]
+
+  # exclude these attributes from being included in client definition
+  # unless they have non-default values
+  %w[
+    keepalive
+    redact
+    socket
+    registration
+    deregistration
+  ].each do |attr|
+    client_attrs << attr unless new_resource.send(attr.to_sym).empty?
+  end
+
+  {
+    'keepalives' => true,
+    'safe_mode' => false,
+    'deregister' => false
+  }.each do |attr, default_value|
+    client_attrs << attr if new_resource.send(attr.to_sym) != default_value
+  end
+
   client = Sensu::Helpers.select_attributes(
     new_resource,
-    %w[name address subscriptions keepalive]
+    client_attrs
   ).merge(new_resource.additional)
 
   definition = {

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -1,9 +1,16 @@
 actions :create
 
 attribute :address, :kind_of => String, :required => true
-attribute :subscriptions, :kind_of => Array, :default => Array.new
-attribute :keepalive, :kind_of => Hash, :default => Hash.new
-attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :subscriptions, :kind_of => Array, :default => []
+attribute :keepalive, :kind_of => Hash, :default => {}
+attribute :keepalives, :kind_of => [TrueClass, FalseClass], :default => true
+attribute :safe_mode, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :redact, :kind_of => Array, :default => []
+attribute :socket, :kind_of => Hash, :default => {}
+attribute :registration, :kind_of => Hash, :default => {}
+attribute :deregister, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :deregistration, :kind_of => Hash, :default => {}
+attribute :additional, :kind_of => Hash, :default => {}
 
 def initialize(*args)
   super
@@ -11,7 +18,5 @@ def initialize(*args)
 end
 
 def after_created
-  unless name =~ /^[\w\.-]+$/
-    raise Chef::Exceptions::ValidationFailed, "Sensu client name cannot contain spaces or special characters"
-  end
+  raise Chef::Exceptions::ValidationFailed, "Sensu client name cannot contain spaces or special characters" unless name =~ /^[\w\.-]+$/
 end

--- a/test/cookbooks/sensu-test/recipes/client_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/client_lwrp.rb
@@ -1,0 +1,13 @@
+sensu_client 'lwrp_client' do
+  address '10.0.0.1'
+  subscriptions ['all']
+  keepalives false
+  keepalive('handler' => 'pagerduty', 'thresholds' => { 'warning' => 40, 'critical' => 60 })
+  safe_mode true
+  redact ['obscure_api_token_name']
+  socket('bind' => '0.0.0.0', 'port' => 4040)
+  registration('handler' => 'register_client')
+  deregister true
+  deregistration('handler' => 'deregister_client')
+  additional('bacon' => true, 'beer' => {'variety' => 'cold'})
+end

--- a/test/cookbooks/sensu-test/recipes/client_lwrp_defaults.rb
+++ b/test/cookbooks/sensu-test/recipes/client_lwrp_defaults.rb
@@ -1,0 +1,4 @@
+sensu_client 'default_client' do
+  address '10.0.0.2'
+  subscriptions ['none']
+end

--- a/test/unit/lwrps/client_spec.rb
+++ b/test/unit/lwrps/client_spec.rb
@@ -1,0 +1,111 @@
+require_relative '../spec_helper'
+
+describe 'sensu_client with minimum required attributes' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      :step_into => %w[sensu_client sensu_json_file]
+    ).converge('sensu-test::client_lwrp_defaults')
+  end
+
+  let(:minimal_client_json) { chef_run.file('/etc/sensu/conf.d/client.json') }
+  let(:minimal_client_content) { JSON.parse(minimal_client_json.content)['client'] }
+
+  it 'renders client.json to directory defined by attributes' do
+    expect(chef_run).to create_sensu_json_file(minimal_client_json.name)
+  end
+
+  it 'configures client name' do
+    expect(minimal_client_content['name']).to eq('default_client')
+  end
+
+  it 'configures client address' do
+    expect(minimal_client_content['address']).to eq('10.0.0.2')
+  end
+
+  it 'configures client subscriptions' do
+    expect(minimal_client_content['subscriptions']).to eq(['none'])
+  end
+
+  it 'does not provide configuration for unconfigured optional attributes' do
+    %w[ deregister deregistration keepalive keepalives redact registration safe_mode socket ].each do
+      |attr|
+      expect(minimal_client_content.key?(attr)).to eq(false)
+    end
+  end
+end
+
+describe 'sensu_client with optional attributes' do
+  let(:sensu_dir) { "/opt/sensu/etc" }
+
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      :step_into => %w[sensu_client sensu_json_file]
+    ) do |node|
+      node.set["sensu"]["directory"] = sensu_dir
+    end.converge('sensu-test::client_lwrp')
+  end
+
+  let(:client_json) { chef_run.file(::File.join(sensu_dir, 'conf.d', 'client.json')) }
+
+  let(:client_content) { JSON.parse(client_json.content)['client'] }
+
+  it 'renders client.json to directory defined by attributes' do
+    expect(chef_run).to create_sensu_json_file(client_json.name)
+  end
+
+  it 'configures client name' do
+    expect(client_content['name']).to eq('lwrp_client')
+  end
+
+  it 'configures client address' do
+    expect(client_content['address']).to eq('10.0.0.1')
+  end
+
+  it 'configures client subscriptions' do
+    expect(client_content['subscriptions']).to eq(['all'])
+  end
+
+  it 'configures client keepalives' do
+    expect(client_content['keepalives']).to eq(false)
+  end
+
+  it 'configures client keepalive behavior' do
+    expect(client_content['keepalive']).to eq(
+      'handler' => 'pagerduty',
+      'thresholds' => {
+        'warning' => 40,
+        'critical' => 60
+      }
+    )
+  end
+
+  it 'configures client safe_mode' do
+    expect(client_content['safe_mode']).to eq(true)
+  end
+
+  it 'configures client socket' do
+    expect(client_content['socket']).to eq('bind' => '0.0.0.0', 'port' => 4040)
+  end
+
+  it 'configures attributes for client redaction' do
+    expect(client_content['redact']).to eq(['obscure_api_token_name'])
+  end
+
+  it 'configures client registration' do
+    expect(client_content['registration']).to eq('handler' => 'register_client')
+  end
+
+  it 'configures client to deregister' do
+    expect(client_content['deregister']).to eq(true)
+  end
+
+  it 'configures client deregistration' do
+    expect(client_content['deregistration']).to eq('handler' => 'deregister_client')
+  end
+
+  it 'configures custom client attributes specified as additional' do
+    expect(client_content['bacon']).to eq(true)
+    expect(client_content['beer']).to eq('variety' => 'cold')
+  end
+
+end


### PR DESCRIPTION
## Description

This change set extends the `sensu_client` provider to support the following additional `client` attributes as defined by the [Sensu Client Reference Documentation](https://sensuapp.org/docs/0.25/reference/clients.html#client-attributes):

* deregister
* deregistration
* keepalives
* redact
* registration
* safe_mode
* socket

## Motivation and Context

Motivated by #395 

Closes #395

## How Has This Been Tested?

Added unit tests for sensu_client provider.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
