### PR TITLE
Fix deprecation warnings, add package tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -70,6 +70,7 @@ suites:
     run_list:
       - recipe[sensu-test]
     excludes:
+      - windows-2008-r2
       - windows-2012-r2
       - centos-5.11
     attributes:

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -33,7 +33,7 @@ if windows["install_dotnet"]
   include_recipe "ms_dotnet::ms_dotnet#{windows['dotnet_major_version']}"
 end
 
-windows_package "Sensu" do
+package "Sensu" do
   source "#{node['sensu']['msi_repo_url']}/sensu-#{node['sensu']['version']}.msi"
   options windows["package_options"]
   version node["sensu"]["version"].tr("-", ".")

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
 
+sensu_pkg_name = windows? ? 'Sensu' : 'sensu'
+
+describe package(sensu_pkg_name) do
+  it { should be_installed }
+end
+
 describe file(File.join(sensu_directory, "config.json")) do
   its(:content) { should match /"name": "test"/ }
   its(:content) { should_not match /"id": / }
-# it { should be_grouped_into('nogroup') } unless windows?
+  # it { should be_grouped_into('nogroup') } unless windows?
 end

--- a/test/unit/common_examples.rb
+++ b/test/unit/common_examples.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'sensu default recipe' do
   context 'ssl is disabled' do
 
     before do
-      chef_run.node.set["sensu"]["use_ssl"] = false
+      chef_run.node.override["sensu"]["use_ssl"] = false
       chef_run.converge(described_recipe)
     end
 

--- a/test/unit/common_examples.rb
+++ b/test/unit/common_examples.rb
@@ -1,4 +1,8 @@
 RSpec.shared_examples 'sensu default recipe' do
+  it "installs the Sensu package" do
+    expect(chef_run).to install_package(sensu_pkg_name)
+  end
+
   it "creates the log directory" do
     expect(chef_run).to create_directory(log_directory).with(
       :owner => 'sensu',

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -19,6 +19,10 @@ describe "sensu::default" do
       expect(chef_run).to include_recipe("sensu::_linux")
     end
 
+    it "installs the sensu package" do
+      expect(chef_run).to install_package('sensu')
+    end
+
     it_behaves_like('sensu default recipe')
   end
 
@@ -43,6 +47,10 @@ describe "sensu::default" do
       expect(chef_run).to include_recipe("sensu::_windows")
     end
 
+    it "installs the Sensu package" do
+      expect(chef_run).to install_package('Sensu')
+    end
+
     context "when install_dotnet is true" do
       it "includes the appropriate recipe from the ms_dotnet cookbook" do
         expect(chef_run).to include_recipe(dotnet_recipe)
@@ -50,7 +58,7 @@ describe "sensu::default" do
     end
 
     context "when install_dotnet is false" do
-      it "includes the appropriate recipe from the ms_dotnet cookbook" do
+      it "does not include a recipe from the ms_dotnet cookbook" do
         chef_run.node.set["sensu"]["windows"]["install_dotnet"] = false
         chef_run.converge(described_recipe)
         expect(chef_run).to_not include_recipe(dotnet_recipe)

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -5,7 +5,7 @@ describe "sensu::default" do
   include_context("sensu data bags")
 
   context "when running on non-windows platform" do
-
+    let(:sensu_pkg_name) { 'sensu' }
     let(:sensu_directory) { '/etc/sensu' }
     let(:log_directory) { '/var/log/sensu' }
 
@@ -27,7 +27,7 @@ describe "sensu::default" do
   end
 
   context "when running on windows platform" do
-
+    let(:sensu_pkg_name) { 'Sensu' }
     let(:sensu_directory) { 'C:\etc\sensu' }
     let(:log_directory) { 'C:\var\log\sensu' }
     let(:dotnet_recipe) { "ms_dotnet::ms_dotnet3" }
@@ -45,10 +45,6 @@ describe "sensu::default" do
 
     it "includes the sensu::_windows recipe" do
       expect(chef_run).to include_recipe("sensu::_windows")
-    end
-
-    it "installs the Sensu package" do
-      expect(chef_run).to install_package('Sensu')
     end
 
     context "when install_dotnet is true" do

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -38,8 +38,8 @@ describe "sensu::default" do
         :version => "2008R2"
       ) do |node, server|
         server.create_data_bag("sensu", ssl_data_bag_item)
-        node.set["lsb"] = {}
-        node.set["sensu"]["windows"]["dotnet_major_version"] = 3
+        node.override["lsb"] = {}
+        node.override["sensu"]["windows"]["dotnet_major_version"] = 3
       end.converge(described_recipe)
     end
 
@@ -55,7 +55,7 @@ describe "sensu::default" do
 
     context "when install_dotnet is false" do
       it "does not include a recipe from the ms_dotnet cookbook" do
-        chef_run.node.set["sensu"]["windows"]["install_dotnet"] = false
+        chef_run.node.override["sensu"]["windows"]["install_dotnet"] = false
         chef_run.converge(described_recipe)
         expect(chef_run).to_not include_recipe(dotnet_recipe)
       end

--- a/test/unit/enterprise_repo.rb
+++ b/test/unit/enterprise_repo.rb
@@ -18,7 +18,7 @@ describe "sensu::_enterprise_repo" do
     context "apt platforms" do
       let(:chef_run) do
         ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
-          node.set["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          node.override["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
           server.create_data_bag("sensu", data_bag_item)
         end.converge(described_recipe)
       end
@@ -36,7 +36,7 @@ describe "sensu::_enterprise_repo" do
 
       context "using custom host with #{repo_designation} repo" do
         before do
-          chef_run.node.set["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.node.override["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
           chef_run.converge(described_recipe)
         end
 
@@ -55,7 +55,7 @@ describe "sensu::_enterprise_repo" do
 
       let(:chef_run) do
         ChefSpec::ServerRunner.new(:platform => "centos", :version => "6.6") do |node, server|
-          node.set["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          node.override["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
           server.create_data_bag("sensu", data_bag_item)
         end.converge(described_recipe)
       end
@@ -73,7 +73,7 @@ describe "sensu::_enterprise_repo" do
 
       context "using custom host with #{repo_designation} repo" do
         before do
-          chef_run.node.set["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.node.override["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
           chef_run.converge(described_recipe)
         end
 

--- a/test/unit/lwrps/base_config_spec.rb
+++ b/test/unit/lwrps/base_config_spec.rb
@@ -87,10 +87,10 @@ describe "sensu_base_config" do
       :version => "14.04",
       :step_into => ['sensu_base_config', 'sensu_json_file']
     ) do |node|
-      node.set["sensu"]["transport"]["chefspec"] = true
-      node.set["sensu"]["redis"]["chefspec"] = true
-      node.set["sensu"]["api"]["chefspec"] = true
-      node.set["sensu"]["rabbitmq"] = single_broker_config
+      node.override["sensu"]["transport"]["chefspec"] = true
+      node.override["sensu"]["redis"]["chefspec"] = true
+      node.override["sensu"]["api"]["chefspec"] = true
+      node.override["sensu"]["rabbitmq"] = single_broker_config
     end.converge("sensu::default")
   end
 
@@ -121,7 +121,7 @@ describe "sensu_base_config" do
   context "multiple rabbitmq hosts provided" do
 
     before do
-      chef_run.node.set["sensu"]["rabbitmq"] = multiple_broker_config
+      chef_run.node.override["sensu"]["rabbitmq"] = multiple_broker_config
       chef_run.converge("sensu::default")
     end
 

--- a/test/unit/lwrps/client_spec.rb
+++ b/test/unit/lwrps/client_spec.rb
@@ -41,7 +41,7 @@ describe 'sensu_client with optional attributes' do
     ChefSpec::SoloRunner.new(
       :step_into => %w[sensu_client sensu_json_file]
     ) do |node|
-      node.set["sensu"]["directory"] = sensu_dir
+      node.override["sensu"]["directory"] = sensu_dir
     end.converge('sensu-test::client_lwrp')
   end
 

--- a/test/unit/lwrps/json_file_spec.rb
+++ b/test/unit/lwrps/json_file_spec.rb
@@ -9,7 +9,7 @@ describe 'sensu_json_file' do
       :step_into => ['sensu_json_file'],
       :file_cache_path => '/tmp'
     ) do |node|
-      node.set['sensu']['directory_mode'] = test_directory_mode
+      node.override['sensu']['directory_mode'] = test_directory_mode
     end.converge('sensu-test::json_file')
   end
 


### PR DESCRIPTION
## Description

This change replaces the use of deprecated `windows_package` resource with the more generic `package` resource and updates unit tests to reduce the number of warnings emitted by the cookbook and its tests.

## Motivation and Context

This change set is intended to reduce the number of warnings the cookbook generates by replacing a deprecated resource declaration in the implementation and updating unit tests.

## How Has This Been Tested?

I added unit and integration tests to assert the Sensu package is installed on both Linux and Windows platforms. These tests passed without any changes to the implementation. Subsequently, I changed the implementation to use `package` instead of `package_windows` and these tests still pass. 👍

I have also successfully tested the test-kitchen default-windows suites locally on Chef 12.5.1 -- the last version of Chef prior to the implementation of native Windows package provider in Chef 12.6 -- and today's latest 12.12.15 via omnibus.

Furthermore, I've replaced the use of `node.set` with `node.override` in the unit tests, which silences another type of deprecation warning.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.