### PR TITLE
Refactor conditional resources in sensu_json_file

### DIFF
--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -3,24 +3,23 @@ action :create do
     r.to_s == "ruby_block[sensu_service_trigger]"
   end
 
-  unless Sensu::JSONFile.compare_content(new_resource.path, new_resource.content)
-    directory ::File.dirname(new_resource.path) do
-      recursive true
-      owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
-      group lazy { new_resource.group || node["sensu"]["group"] }
-      mode lazy { node["sensu"]["directory_mode"] }
-    end
-
-    f = file new_resource.path do
-      owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
-      group lazy { new_resource.group || node["sensu"]["group"] }
-      mode new_resource.mode
-      content Sensu::JSONFile.dump_json(new_resource.content)
-      notifies :create, "ruby_block[sensu_service_trigger]", :delayed if sensu_service_trigger
-    end
-
-    new_resource.updated_by_last_action(f.updated_by_last_action?)
+  directory "create_dir_for_#{new_resource.path}" do
+    path ::File.dirname(new_resource.path)
+    recursive true
+    owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
+    group lazy { new_resource.group || node["sensu"]["group"] }
+    mode lazy { node["sensu"]["directory_mode"] }
   end
+
+  f = file new_resource.path do
+    owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
+    group lazy { new_resource.group || node["sensu"]["group"] }
+    mode new_resource.mode
+    content Sensu::JSONFile.dump_json(new_resource.content)
+    notifies :create, "ruby_block[sensu_service_trigger]", :delayed if sensu_service_trigger
+  end
+
+  new_resource.updated_by_last_action(f.updated_by_last_action?)
 end
 
 action :delete do

--- a/test/unit/lwrps/json_file_spec.rb
+++ b/test/unit/lwrps/json_file_spec.rb
@@ -1,9 +1,8 @@
 require_relative "../spec_helper"
 
 describe 'sensu_json_file' do
-
+  let(:test_content) { { :lol => "wtfbbq" } }
   let(:test_directory_mode) { "0755" }
-
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
       :step_into => ['sensu_json_file'],
@@ -15,6 +14,12 @@ describe 'sensu_json_file' do
 
   it 'creates the /etc/sensu directory using value of directory_mode attribute' do
     expect(chef_run).to create_directory('/etc/sensu').with({ :mode => test_directory_mode })
+  end
+
+  it 'creates a "pretty" json file with the provided content' do
+    expect(chef_run).to render_file('/etc/sensu/foo.json').with_content(
+      JSON.pretty_generate(test_content)
+    )
   end
 
 end


### PR DESCRIPTION
## Description

This change set removes the `unless` condition around the `directory` and `file` resources defined by the `sensu_json_file` provider. Unconditionally defining these resources ensures that every file we intend to manage with `sensu_json_file` is represented in the resource collection.
 
## Motivation and Context

Inspired by changes suggested by @troyready in https://github.com/sensu/sensu-chef/pull/471#issuecomment-237362243.

As described in #388, the current code does not define resources for files which already exist on disk with the desired content, which makes it difficult or impossible to use library cookbooks like [zap](https://supermarket.chef.io/cookbooks/zap) to ensure that files no longer managed by Chef are deleted from the file system.

Closes #388 
Relates to #288 
Relates to #471

## How Has This Been Tested?

Unit and integration tests pass; added new unit test to validate file is rendered with expected content.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.