### PR TITLE
bumping default version to 0.25.6-1

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ else
 end
 
 # installation
-default["sensu"]["version"] = "0.25.1-1"
+default["sensu"]["version"] = "0.25.6-1"
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true


### PR DESCRIPTION
## Description

Bump default Sensu version to latest release.

## Motivation and Context

Using the latest version ensures we are have the latest bug fixes 👍 

## How Has This Been Tested?

Converges in test-kitchen 👌

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
