### PR TITLE
Add SENSU_LOADED_TEMPFILE_DIR to Sensu config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Sensu services, "sysv" and "runit" are currently supported.
 `node["sensu"]["service_max_wait"]` - How long service scripts should wait
 for Sensu to start/stop.
 
+`node["sensu"]["loaded_tempfile_dir"]` - Where Sensu stores temporary files. Change to other directory if you use hardened system that cleans temporary directory regularly. Default "/tmp"
+
 ### Windows
 
 Sensu requires Microsoft's .Net Framework to run on Windows. The following attributes influence the installation of .Net via this cookbook:

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Sensu services, "sysv" and "runit" are currently supported.
 `node["sensu"]["service_max_wait"]` - How long service scripts should wait
 for Sensu to start/stop.
 
-`node["sensu"]["loaded_tempfile_dir"]` - Where Sensu stores temporary files. Change to other directory if you use hardened system that cleans temporary directory regularly. Default "/tmp"
+`node["sensu"]["loaded_tempfile_dir"]` - Where Sensu stores temporary files. Set a persistent directory if you use hardened system that cleans temporary directory regularly.
 
 ### Windows
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,7 +28,6 @@ default["sensu"]["directory_mode"] = "0750"
 default["sensu"]["log_directory_mode"] = "0750"
 default["sensu"]["client_deregister_on_stop"] = false
 default["sensu"]["client_deregister_handler"] = nil
-default["sensu"]["loaded_tempfile_dir"] = "/tmp"
 
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default["sensu"]["directory_mode"] = "0750"
 default["sensu"]["log_directory_mode"] = "0750"
 default["sensu"]["client_deregister_on_stop"] = false
 default["sensu"]["client_deregister_handler"] = nil
+default["sensu"]["loaded_tempfile_dir"] = "/tmp"
 
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -4,4 +4,4 @@ LOG_LEVEL=<%= node["sensu"]["log_level"] %>
 SERVICE_MAX_WAIT=<%= node["sensu"]["service_max_wait"] %>
 CLIENT_DEREGISTER_ON_STOP=<%= node["sensu"]["client_deregister_on_stop"] %>
 <%= node["sensu"]["client_deregister_handler"] ? %|CLIENT_DEREGISTER_HANDLER=#{node["sensu"]["client_deregister_handler"]}| : nil %>
-export SENSU_LOADED_TEMPFILE_DIR=<%= node["sensu"]["loaded_tempfile_dir"] %>
+<%= node["sensu"]["loaded_tempfile_dir"] ? %|export SENSU_LOADED_TEMPFILE_DIR=#{node["sensu"]["loaded_tempfile_dir"]}| : nil %>

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -4,3 +4,4 @@ LOG_LEVEL=<%= node["sensu"]["log_level"] %>
 SERVICE_MAX_WAIT=<%= node["sensu"]["service_max_wait"] %>
 CLIENT_DEREGISTER_ON_STOP=<%= node["sensu"]["client_deregister_on_stop"] %>
 <%= node["sensu"]["client_deregister_handler"] ? %|CLIENT_DEREGISTER_HANDLER=#{node["sensu"]["client_deregister_handler"]}| : nil %>
+export SENSU_LOADED_TEMPFILE_DIR=<%= node["sensu"]["loaded_tempfile_dir"] %>


### PR DESCRIPTION
This adds "export SENSU_LOADED_TEMPFILE_DIR=some_dir" to /etc/default/sensu.

## Description
In some linux distros and hardened systems, /tmp directory is regularly cleaned. When Sensu loses files such as "sensu_server_loaded_files" in /tmp directory, its handlers will fail with the following error.

{"timestamp":"2016-08-21T11:38:46.043506+0000","level":"info","message":"handler output","handler":{"type":"pipe","command":"handler-hipchat.rb","name":"hipchat"},"output":["/opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `read': No such file or directory @ rb_sysopen - /tmp/sensu_server_loaded_files (Errno::ENOENT)\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:7:in `config_files'\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-plugin/utils.rb:20:in `settings'\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:104:in `filter_repeated'\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:30:in `filter'\n\tfrom /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugin-1.2.0/lib/sensu-handler.rb:54:in `block in <class:Handler>'\n"]}

To resolve the problem, an environment variable SENSU_LOADED_TEMPFILE_DIR was introduced to Sensu by the following commit.

https://github.com/sensu/sensu-settings/commit/c21d471a40ce9c1991f8a38d19bfe28efd387703

This pull request is to add a new attribute that sets up the environment variable in Sensu config file.

## Motivation and Context

https://github.com/sensu/sensu-chef/issues/486

## How Has This Been Tested?
I have tested the following suites in test-kitchen.
- default-ubuntu-1404
- default-centos-67

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
