### PR TITLE
Fix sensitive supported check

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -87,7 +87,7 @@ if node["sensu"]["use_ssl"]
     owner node["sensu"]["admin_user"]
     group node["sensu"]["group"]
     mode 0640
-    sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
+    sensitive true if respond_to?(:sensitive)
   end
 else
   if node["sensu"]["rabbitmq"].port == 5671

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -52,7 +52,7 @@ if node["sensu"]["use_ssl"]
       content lazy { get_sensu_state(node, "ssl", "server", item) }
       group "rabbitmq"
       mode 0640
-      sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
+      sensitive true if respond_to?(:sensitive)
     end
     node.override["rabbitmq"]["ssl_#{item}"] = path
   end
@@ -68,7 +68,7 @@ if node["sensu"]["use_ssl"]
       content lazy { get_sensu_state(node, "ssl", "client", item) }
       group "rabbitmq"
       mode 0640
-      sensitive true if Chef::Resource::ChefGem.instance_methods(false).include?(:sensitive)
+      sensitive true if respond_to?(:sensitive)
     end
   end
 end


### PR DESCRIPTION
## Description
The sensitive check currently uses the ChefGem resource to see if the attribute exists. But even on the newer Chef versions this does not exist (makes no sense either). Check on the File resource instead.

## Motivation and Context
In the current code `sensitive` will never be used, even if supported.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
