### PR TITLE
Updating unit tests lacking a platform and version for their chefspec runner

### DIFF
--- a/test/unit/check_spec.rb
+++ b/test/unit/check_spec.rb
@@ -1,7 +1,11 @@
 require_relative 'spec_helper'
 
 describe 'sensu-test::good_checks' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) {
+    ChefSpec::SoloRunner.new(:platform => 'ubuntu', :version => '14.04').converge(
+      described_recipe
+    )
+  }
 
   it "creates valid_standalone_check sensu_check" do
     expect(chef_run).to create_sensu_check("valid_standalone_check").with(:standalone => true)
@@ -14,7 +18,11 @@ describe 'sensu-test::good_checks' do
 end
 
 describe 'sensu-test::bad_check_name' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) {
+    ChefSpec::SoloRunner.new(:platform => 'ubuntu', :version => '14.04').converge(
+      described_recipe
+    )
+  }
 
   it "raises an exception when the check name contains invalid characters" do
     expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)
@@ -22,7 +30,11 @@ describe 'sensu-test::bad_check_name' do
 end
 
 describe 'sensu-test::bad_check_attributes' do
-  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }
+  let(:chef_run) {
+    ChefSpec::SoloRunner.new(:platform => 'ubuntu', :version => '14.04').converge(
+      described_recipe
+    )
+  }
 
   it "raises an exception when the check has neither subscribers nor standalone attributes" do
     expect { chef_run }.to raise_error(Chef::Exceptions::ValidationFailed)

--- a/test/unit/lwrps/client_spec.rb
+++ b/test/unit/lwrps/client_spec.rb
@@ -3,7 +3,9 @@ require_relative '../spec_helper'
 describe 'sensu_client with minimum required attributes' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      :step_into => %w[sensu_client sensu_json_file]
+      :step_into => %w[sensu_client sensu_json_file],
+      :platform => "ubuntu",
+      :version => "14.04"
     ).converge('sensu-test::client_lwrp_defaults')
   end
 
@@ -39,7 +41,9 @@ describe 'sensu_client with optional attributes' do
 
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      :step_into => %w[sensu_client sensu_json_file]
+      :step_into => %w[sensu_client sensu_json_file],
+      :platform => "ubuntu",
+      :version => "14.04"
     ) do |node|
       node.override["sensu"]["directory"] = sensu_dir
     end.converge('sensu-test::client_lwrp')

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -4,7 +4,9 @@ describe 'sensu_gem' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
       :step_into => ['sensu_gem'],
-      :file_cache_path => '/tmp'
+      :file_cache_path => '/tmp',
+      :platform => 'ubuntu',
+      :version => '14.04'
     ).converge('sensu-test::gem_lwrp')
   end
 

--- a/test/unit/lwrps/json_file_spec.rb
+++ b/test/unit/lwrps/json_file_spec.rb
@@ -6,7 +6,9 @@ describe 'sensu_json_file' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
       :step_into => ['sensu_json_file'],
-      :file_cache_path => '/tmp'
+      :file_cache_path => '/tmp',
+      :platform => "ubuntu",
+      :version => "14.04"
     ) do |node|
       node.override['sensu']['directory_mode'] = test_directory_mode
     end.converge('sensu-test::json_file')


### PR DESCRIPTION
## Description

Updating unit tests where ChefSpec runner objects lacked a platform and version.

## Motivation and Context

Appears upstream change in erlang cookbook now expects node['lsb'] attributes to
be set, breaking our unit test chef runs. This change fixes the build. 

## How Has This Been Tested?

Running unit tests ✅

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.

