### PR TITLE
Update Sensu client version for Windows

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,7 +32,7 @@ platforms:
     driver:
       http_proxy: null
       https_proxy: null
-      box: windows-2012r2
+      box: mwrock/Windows2012R2
     customize:
       memory: 2048
     attributes:

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :integration do
   gem "test-kitchen", "~> 1.8"
   gem "kitchen-docker"
   gem "kitchen-vagrant"
+  gem "winrm", "~> 2.0"
   gem "winrm-fs"
-  gem "winrm-transport"
   gem "winrm-elevated"
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ else
 end
 
 # installation
-default["sensu"]["version"] = "0.25.6-1"
+default["sensu"]["version"] = platform_family?("windows") ? "0.25.5-1" : "0.25.6-1"
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true


### PR DESCRIPTION
Update the default Sensu client version for Windows since `0.25.6-1` does not exist for Windows.

## Description
Update the default Sensu client version for Windows since `0.25.6-1` does not exist for Windows.

I also made some updates to `Gemfile` and `.kitchen.yml` to get `test-kitchen` working for windows converges.

## Motivation and Context
Update the default Sensu client version for Windows since `0.25.6-1` does not exist for Windows.

## How Has This Been Tested?
Tested in in test-kitchen.  Before updates would receive error:

```
           * remote_file[C:\Users\vagrant\AppData\Local\Temp\kitchen\cache\package\sensu-0.25.6-1.msi] action create
       
       
             ================================================================================
             Error executing action `create` on resource 'remote_file[C:\Users\vagrant\AppData\Local\Temp\kitchen\cache\package\sensu-0.25.6-1.msi]'
             ================================================================================
       
             Net::HTTPServerException
             ------------------------
             404 "Not Found"
```

After updates it converges fine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.