### PR TITLE
Fix url parameter for yum_repository resource

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -48,7 +48,7 @@ when "rhel", "fedora"
   repo = yum_repository "sensu" do
     description "sensu monitoring"
     repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"
-    url "#{node['sensu']['yum_repo_url']}/#{repo}/$basearch/"
+    baseurl "#{node['sensu']['yum_repo_url']}/#{repo}/$basearch/"
     action :add
     only_if { node["sensu"]["add_repo"] }
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, use of `url` parameter for the `yum_repository` resource causes chef-client to fail during run. It's also been deprecated in favor of using `baseurl`.

## Motivation and Context
Replace `url` parameter with the use of `baseurl`.

Issue: https://github.com/chef/chef/issues/5317

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.