### PR TITLE
Add support for AIX platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
-default["sensu"]["aix_download_location"] = "https://core.sensuapp.com/aix/unstable/sensu-0.26.1-3.powerpc.bff"
+default["sensu"]["aix_download_location"] = "https://core.sensuapp.com/aix-unstable/sensu-0.26.1-3.powerpc.bff"
 default["sensu"]["add_repo"] = true
 
 # transport

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
-default["sensu"]["aix_download_location"] = "https://sensu.global.ssl.fastly.net/aix/sensu-0.26.1-1.powerpc.bff"
+default["sensu"]["aix_download_location"] = "https://core.sensuapp.com/aix/unstable/sensu-0.26.1-3.powerpc.bff"
 default["sensu"]["add_repo"] = true
 
 # transport

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
+default["sensu"]["aix_download_location"] = "https://sensu.global.ssl.fastly.net/aix/sensu-0.26.1-1.powerpc.bff"
 default["sensu"]["add_repo"] = true
 
 # transport

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
-default["sensu"]["aix_package_url"] = "https://core.sensuapp.com/aix-unstable/sensu-0.26.1-3.powerpc.bff"
+default["sensu"]["aix_package_root_url"] = "https://sensu.global.ssl.fastly.net/aix"
 default["sensu"]["add_repo"] = true
 
 # transport

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,7 +32,7 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
-default["sensu"]["aix_download_location"] = "https://core.sensuapp.com/aix-unstable/sensu-0.26.1-3.powerpc.bff"
+default["sensu"]["aix_package_url"] = "https://core.sensuapp.com/aix-unstable/sensu-0.26.1-3.powerpc.bff"
 default["sensu"]["add_repo"] = true
 
 # transport

--- a/metadata.rb
+++ b/metadata.rb
@@ -28,6 +28,7 @@ depends "redisio", ">= 1.7.0"
 suggests "chef-vault", ">= 1.3.1"
 
 %w[
+  aix
   ubuntu
   debian
   centos

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -37,6 +37,8 @@ def load_current_resource
   @sensu_svc ||= case new_resource.init_style
   when "sysv"
     service_provider = case node["platform_family"]
+    when /aix/
+      Chef::Provider::Service::Aix
     when /debian/
       Chef::Provider::Service::Init::Debian
     when /windows/

--- a/recipes/_aix.rb
+++ b/recipes/_aix.rb
@@ -1,0 +1,32 @@
+#
+# Cookbook Name:: sensu
+# Recipe:: _aix
+#
+# Copyright 2016, Heavy Water Operations, LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
+remote_file bff_path do
+  source node["sensu"]["aix_download_location"]
+end
+
+package "sensu" do
+  source bff_path
+end
+
+template "/etc/default/sensu" do
+  source "sensu.default.erb"
+  notifies :create, "ruby_block[sensu_service_trigger]"
+end

--- a/recipes/_aix.rb
+++ b/recipes/_aix.rb
@@ -20,7 +20,7 @@
 bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
 
 remote_file bff_path do
-  source node["sensu"]["aix_package_url"]
+  source "#{node["sensu"]["aix_package_root_url"]}/sensu-#{node["sensu"]["version"]}.powerpc.bff"
 end
 
 package "sensu" do

--- a/recipes/_aix.rb
+++ b/recipes/_aix.rb
@@ -18,8 +18,9 @@
 #
 
 bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
+
 remote_file bff_path do
-  source node["sensu"]["aix_download_location"]
+  source node["sensu"]["aix_package_url"]
 end
 
 package "sensu" do

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -20,6 +20,15 @@
 platform_family = node["platform_family"]
 
 case platform_family
+when "aix"
+  bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
+  remote_file bff_path do
+    source node["sensu"]["aix_download_location"]
+  end
+
+  package "sensu" do
+    source bff_path
+  end
 when "debian"
   include_recipe "apt"
 

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -20,15 +20,6 @@
 platform_family = node["platform_family"]
 
 case platform_family
-when "aix"
-  bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
-  remote_file bff_path do
-    source node["sensu"]["aix_download_location"]
-  end
-
-  package "sensu" do
-    source bff_path
-  end
 when "debian"
   include_recipe "apt"
 

--- a/recipes/client_service.rb
+++ b/recipes/client_service.rb
@@ -17,7 +17,15 @@
 # limitations under the License.
 #
 
+service_actions = case node['platform_family']
+when 'aix'
+  [:start]
+else
+  [:enable, :start]
+end
+
+
 sensu_service "sensu-client" do
   init_style node["sensu"]["init_style"]
-  action [:enable, :start]
+  action service_actions
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,8 +25,11 @@ ruby_block "sensu_service_trigger" do
   action :nothing
 end
 
-if platform_family?("windows")
+case node["platform_family"]
+when "windows"
   include_recipe "sensu::_windows"
+when "aix"
+  include_recipe "sensu::_aix"
 else
   include_recipe "sensu::_linux"
 end

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -4,26 +4,46 @@ require_relative "common_examples"
 describe "sensu::default" do
   include_context("sensu data bags")
 
-  context "when running on non-windows platform" do
+  context "when running on unix-like platforms" do
     let(:sensu_pkg_name) { 'sensu' }
     let(:sensu_directory) { '/etc/sensu' }
     let(:log_directory) { '/var/log/sensu' }
 
-    let(:chef_run) do
-      ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
-        server.create_data_bag("sensu", ssl_data_bag_item)
-      end.converge(described_recipe)
+    context "when running on ubuntu linux" do
+      let(:chef_run) do
+        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+          server.create_data_bag("sensu", ssl_data_bag_item)
+        end.converge(described_recipe)
+      end
+
+      it "includes the sensu::_linux recipe" do
+        expect(chef_run).to include_recipe("sensu::_linux")
+      end
+
+      it "installs the sensu package" do
+        expect(chef_run).to install_package('sensu')
+      end
+
+      it_behaves_like('sensu default recipe')
     end
 
-    it "includes the sensu::_linux recipe" do
-      expect(chef_run).to include_recipe("sensu::_linux")
-    end
+    context "when running on aix" do
+      let(:chef_run) do
+        ChefSpec::ServerRunner.new(:platform => "aix", :version => "7.1") do |node, server|
+          server.create_data_bag("sensu", ssl_data_bag_item)
+        end.converge(described_recipe)
+      end
 
-    it "installs the sensu package" do
-      expect(chef_run).to install_package('sensu')
-    end
+      it "includes the sensu::_linux recipe" do
+        expect(chef_run).to include_recipe("sensu::_linux")
+      end
 
-    it_behaves_like('sensu default recipe')
+      it "installs the sensu package" do
+        expect(chef_run).to install_package('sensu')
+      end
+
+      it_behaves_like('sensu default recipe')
+    end
   end
 
   context "when running on windows platform" do

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -34,8 +34,8 @@ describe "sensu::default" do
         end.converge(described_recipe)
       end
 
-      it "includes the sensu::_linux recipe" do
-        expect(chef_run).to include_recipe("sensu::_linux")
+      it "includes the sensu::_aix recipe" do
+        expect(chef_run).to include_recipe("sensu::_aix")
       end
 
       it "installs the sensu package" do


### PR DESCRIPTION
## Description

Adds support for retrieving and installing Sensu via BFF package on AIX platforms.

## Motivation and Context

AIX is currently not supported by this cookbook, which causes an exception to be raised.

## How Has This Been Tested?

Tested `default` and `client_service` recipes on AIX 6.1 and 7.1 systems using chef-client in local mode.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.