### PR TITLE
[rabbitmq_credentials] remove unnecessary reference to undefined variable "key"

### DIFF
--- a/definitions/rabbitmq_credentials.rb
+++ b/definitions/rabbitmq_credentials.rb
@@ -1,5 +1,5 @@
 define :rabbitmq_credentials do
-  unless get_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], key)
+  unless get_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user])
     rabbitmq_vhost params[:vhost] do
       action :add
     end
@@ -11,6 +11,6 @@ define :rabbitmq_credentials do
       action [:add, :set_permissions]
     end
 
-    set_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], key, true)
+    set_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], true)
   end
 end

--- a/test/cookbooks/sensu-test/recipes/rabbitmq_credentials.rb
+++ b/test/cookbooks/sensu-test/recipes/rabbitmq_credentials.rb
@@ -1,0 +1,6 @@
+rabbitmq_credentials "test" do
+  vhost "test"
+  user "testuser"
+  password "testpassword"
+  permissions ".* .* .*"
+end

--- a/test/unit/definitions/rabbitmq_credentials.rb
+++ b/test/unit/definitions/rabbitmq_credentials.rb
@@ -1,0 +1,31 @@
+require_relative "../spec_helper"
+
+describe "sensu-test::rabbitmq_credentials" do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new(
+      :platform => "ubuntu",
+      :version => "12.04"
+    ).converge(described_recipe)
+  end
+
+  let(:rmq_state_set) do
+    chef_run.node.run_state['sensu']['rabbitmq_credentials']['test']['testuser']
+  end
+
+  it "creates the rabbitmq vhost" do
+    expect(chef_run).to add_rabbitmq_vhost("test")
+  end
+
+  it "creates the rabbitmq user" do
+    expect(chef_run).to add_rabbitmq_user("testuser").with(
+      :password => "testpassword",
+      :vhost => "test",
+      :permissions => ".* .* .*",
+      :action => [:add, :set_permissions]
+    )
+  end
+
+  it "sets state in node.run_state to avoid CHEF-3694 warnings" do
+    expect(rmq_state_set).to eq(true)
+  end
+end


### PR DESCRIPTION
## Description

Seems that #466 contains a regression causing test-kitchen runs to fail due to
undefined variable "key" being passed when invoking `rabbitmq_credentials`
definition. I believe removing this undefined variable from the arguments will
fix the problem and the code will otherwise function as expected.

~~Needs tests :)~~

## Motivation and Context

Current test-kitchen sysv suite is broken on `develop` branch.

```
         Recipe Compile Error in /tmp/kitchen/cache/cookbooks/sensu-test/recipes/default.rb
       
         NameError
         ---------
         No resource, method, or local variable named `key' for `Chef::Recipe "rabbitmq"'

         Cookbook Trace:
         ---------------
           /tmp/kitchen/cache/cookbooks/sensu/definitions/rabbitmq_credentials.rb:2:in `block in from_file'
           /tmp/kitchen/cache/cookbooks/sensu/recipes/rabbitmq.rb:97:in `from_file'
           /tmp/kitchen/cache/cookbooks/sensu-test/recipes/default.rb:37:in `from_file'

         Relevant File Content:
         ----------------------
         /tmp/kitchen/cache/cookbooks/sensu/definitions/rabbitmq_credentials.rb:

           1:  define :rabbitmq_credentials do
           2>>   unless get_sensu_state(node, :rabbitmq_credentials, params[:vhost], params[:user], key)
           3:      rabbitmq_vhost params[:vhost] do
           4:        action :add
           5:      end
           6:
           7:      rabbitmq_user params[:user] do
           8:        password params[:password]
           9:        vhost params[:vhost]
          10:        permissions params[:permissions] || ".* .* .*"
          11:        action [:add, :set_permissions]
```

## How Has This Been Tested?

* test-kitchen suites now pass
* Update: added unit test coverage for `rabbitmq_credentials` definition

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.