### PR TITLE
Fix _enterprise_repo include in enterprise_dashboard.

### DIFF
--- a/recipes/enterprise_dashboard.rb
+++ b/recipes/enterprise_dashboard.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "sensu::_enterprise_repo.rb"
+include_recipe "sensu::_enterprise_repo"
 
 package "sensu-enterprise-dashboard" do
   version node["sensu"]["enterprise-dashboard"]["version"]


### PR DESCRIPTION
## Description
Removed an invalid trailing .rb from `sensu::enterprise_dashboard`'s inclusion of `sensu::_enterprise_repo`

## Motivation and Context
`sensu::enterprise_dashboard` didn't work. Now it does.

Fixes #448 

## How Has This Been Tested?
Kitchen

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
