### PR TITLE
Expand metadata and depend on mildly modern apt/yum/windows

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,8 +1,6 @@
 ---
 driver:
   name: vagrant
-  customize:
-    memory: 512
 
 provisioner:
   name: chef_zero
@@ -10,8 +8,10 @@ provisioner:
 platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-5.11
-  - name: centos-6.7
+  - name: centos-6.8
+  - name: centos-7.2
   - name: windows-2008-r2
     transport:
       name: winrm

--- a/chefignore
+++ b/chefignore
@@ -1,12 +1,21 @@
-# Put files/directories that should be ignored in this file.
+# Put files/directories that should be ignored in this file when uploading
+# to a chef-server or supermarket.
 # Lines that start with '# ' are comments.
 
-## OS
+# OS generated files #
+######################
 .DS_Store
 Icon?
 nohup.out
+ehthumbs.db
+Thumbs.db
 
-## EDITORS
+# SASS #
+########
+.sass-cache
+
+# EDITORS #
+###########
 \#*
 .#*
 *~
@@ -22,37 +31,72 @@ tmtags
 .settings
 mkmf.log
 
-## COMPILED
+## COMPILED ##
+##############
 a.out
 *.o
 *.pyc
 *.so
+*.com
+*.class
+*.dll
+*.exe
+*/rdoc/
 
-## OTHER SCM
-*/.bzr/*
-*/.hg/*
-*/.svn/*
-
-## Don't send rspecs up in cookbook
+# Testing #
+###########
 .watchr
 .rspec
 spec/*
 spec/fixtures/*
+test/*
 features/*
+examples/*
+Guardfile
+Procfile
+.kitchen*
+.rubocop.yml
+spec/*
+Rakefile
+.travis.yml
+.foodcritic
+.codeclimate.yml
 
-## SCM
+# SCM #
+#######
+.git
+*/.git
 .gitignore
-.github/*
+.gitmodules
+.gitconfig
+.gitattributes
+.svn
+*/.bzr/*
+*/.hg/*
+*/.svn/*
 
-# Berkshelf
+# Berkshelf #
+#############
 Berksfile
 Berksfile.lock
 cookbooks/*
+tmp
 
-# Vagrant
+# Cookbooks #
+#############
+CONTRIBUTING*
+CHANGELOG*
+TESTING*
+MAINTAINERS.toml
+
+# Strainer #
+############
+Colanderfile
+Strainerfile
+.colander
+.strainer
+
+# Vagrant #
+###########
 .vagrant
-
-# test-kitchen
-.kitchen
-.kitchen*.yml*
-.nellie
+Vagrantfile

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ depends "apt", ">= 2.0"
 depends "yum", ">= 3.0"
 
 # available @ https://supermarket.chef.io/cookbooks/windows
-depends "windows", ">= 1.8.8"
+depends "windows", ">= 1.36"
 
 # available @ https://supermarket.chef.io/cookbooks/ms_dotnet
 depends "ms_dotnet", ">= 2.6.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -41,5 +41,6 @@ suggests "chef-vault", ">= 1.3.1"
   supports os
 end
 
-source_url 'https://github.com/sensu/sensu-chef' if respond_to?(:source_url)
-issues_url 'https://github.com/sensu/sensu-chef/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/sensu/sensu-chef'
+issues_url 'https://github.com/sensu/sensu-chef/issues'
+chef_version '>= 12.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,10 +7,10 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "3.0.1"
 
 # available @ https://supermarket.chef.io/cookbooks/apt
-depends "apt"
+depends "apt", ">= 2.0"
 
 # available @ https://supermarket.chef.io/cookbooks/yum
-depends "yum"
+depends "yum", ">= 3.0"
 
 # available @ https://supermarket.chef.io/cookbooks/windows
 depends "windows", ">= 1.8.8"


### PR DESCRIPTION
## Description

A few minor cleanup commits, expansion of the metadata with chef_version, and the requirement that the user have apt 2.0 and yum 3.0, which ensures they have apt/yum that will work with this cookbook. Also require a windows cookbook that is compatible with Chef 12.

## Motivation and Context
Just some general cleanup

## How Has This Been Tested?
Test Kitchen can't resolve deps without Berks or Policyfiles so I'm unable to run a Test Kitchen run on this, but it's all pretty straight forward

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.