### PR TITLE
Replace librarian-chef with berkshelf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,8 @@ examples/ssl/sensu_ca
 .vagrant
 \#*
 .bundle/
-.librarian/
 .kitchen/
 .kitchen.local.yml
-tmp
-Berksfile
 test/integration/enterprise/data_bags/sensu/enterprise.json
 test/integration/enterprise-dashboard/data_bags/sensu/enterprise.json
 .envrc

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,6 @@
+source 'https://supermarket.chef.io'
+metadata
+
+group :integration do
+  cookbook "sensu-test", path: "test/cookbooks/sensu-test"
+end

--- a/Cheffile
+++ b/Cheffile
@@ -1,4 +1,0 @@
-site "http://community.opscode.com/api/v1"
-
-cookbook "sensu", path: "."
-cookbook "sensu-test", path: "test/cookbooks/sensu-test"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
   gem "emeril", "~> 0.8"
-  gem "librarian-chef"
+  gem "berkshelf"
   gem "rake"
   gem "guard"
   gem "guard-foodcritic"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
   gem "emeril", "~> 0.8"
-  gem "berkshelf"
+  gem "berkshelf", "~> 5.0"
   gem "rake"
   gem "guard"
   gem "guard-foodcritic"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
   gem "emeril", "~> 0.8"
-  gem "berkshelf", "~> 5.0"
+  gem "berkshelf", "= 4.3.0", "< 6.0"
   gem "rake"
   gem "guard"
   gem "guard-foodcritic"

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/librarian'
+require 'chefspec/berkshelf'
 
 ChefSpec::Coverage.start!
 


### PR DESCRIPTION
## Description

Replace librarian-chef with berkshelf for this project's cookbook dependency resolution.

## Motivation and Context

librarian-chef currently fails to resolve our dependencies. This
seems to have something to do with its graphs for erlang and various yum*
cookbook dependencies but I haven't been able to zero in on a satisfactory
cause.

## How Has This Been Tested?

Unit tests pass, subset of test-kitchen runs pass.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
