### PR TITLE
Restore windows platform logic to Sensu::Helpers.gem_binary

### DIFF
--- a/libraries/sensu_helpers.rb
+++ b/libraries/sensu_helpers.rb
@@ -31,6 +31,8 @@ module Sensu
       def gem_binary
         if File.exists?("/opt/sensu/embedded/bin/gem")
           "/opt/sensu/embedded/bin/gem"
+        elsif File.exists?('c:\opt\sensu\embedded\bin\gem.bat')
+          'c:\opt\sensu\embedded\bin\gem.bat'
         else
           "gem"
         end

--- a/test/cookbooks/sensu-test/recipes/asset.rb
+++ b/test/cookbooks/sensu-test/recipes/asset.rb
@@ -49,3 +49,7 @@ profiler_extension = case platform?('windows')
 sensu_asset profiler_extension do
   asset_directory File.join(node.sensu.directory, "extensions")
 end
+
+# adding a simple plugin gem here so we can test gem installation on windows
+# without dealing with the chefspec-oriented gem_lwrp recipe
+sensu_gem 'sensu-plugins-pushover'


### PR DESCRIPTION
## Description

This change restores platform-specific logic for determining the ruby gem path on Windows. Originally this logic was added in #393 but lost in a git accident. 😓

## Motivation and Context

Closes #483 

## How Has This Been Tested?

* Unit test coverage for Sensu::Helpers.gem_binary has been expanded
* Added sensu_gem resource to `sensu-test::asset` recipe to ensure sensu_gem is exercised when Test Kitchen is run (the `sensu-test::gem_lwrp` recipe may seem like a more natural fit, but it is more directly oriented at unit testing the sensu_gem LWRP).
* `asset-windows-2012r2` test suite passes with the above changes

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.