### PR TITLE
bumping default version to 0.26.3-1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ### Changes
 
-Eliminated CHEF-3694 warnings when calling rabbitmq_credentials definition
+The default version of Sensu installed by this cookbook is now 0.26.3-1.
 
-Replaced librarian-chef with Berkshelf
+Eliminated resource cloning warnings when calling rabbitmq_credentials definition.
 
-Updated test-kitchen configuration for windows platforms
+Replaced librarian-chef with Berkshelf.
 
-Updated metadata to depend on Chef >= 12
+Updated test-kitchen configuration for windows platforms.
 
-Updated metadata to depend on "more modern" versions of yum, apt and windows cookbooks
+Updated metadata to depend on Chef >= 12.
+
+Updated dependencies for yum, apt and windows cookbooks to make sense for Chef >= 12.
 
 ### Features
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,7 @@ else
 end
 
 # installation
-default["sensu"]["version"] = platform_family?("windows") ? "0.25.5-1" : "0.25.6-1"
+default["sensu"]["version"] = "0.26.3-1"
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true


### PR DESCRIPTION
## Description

Sensu Core 0.26.3-1 is now available for all supported platforms via the stable channel. This change updates the default value of the `version` attribute from 0.25.6-1 to 0.26.3-1.

## Motivation and Context

I believe that each time we cut a new release of this cookbook, it should install the most recent stable version of Sensu available at the time.

## How Has This Been Tested?

I have tested the Linux and Windows test-kitchen platforms with this new default version. I have also manually tested this change on an AIX 6.1 system.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
