### PR TITLE
Ensure yum is configured with both `noarch` and `$basearch` repositories when installing Sensu Enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Changes
+
+The `_enterprise_repo` recipe now configures yum repos for both `noarch`
+and `$basearch` so that `sensu-enterprise-dashboard` package can be installed.
+
+Due to upstream repository changes, the default value of
+`node['sensu']['enterprise-dashboard]['version']` has changed from
+`1:1.4.0-1` to `1.4.0-1`.
+
 ## [3.1.0] - 2016-09-23
 
 ### Changes

--- a/attributes/enterprise_dashboard.rb
+++ b/attributes/enterprise_dashboard.rb
@@ -1,5 +1,5 @@
 # installation
-default["sensu"]["enterprise-dashboard"]["version"] = "1:1.4.0-1"
+default["sensu"]["enterprise-dashboard"]["version"] = "1.4.0-1"
 
 # data bag
 default["sensu"]["enterprise-dashboard"]["data_bag"]["name"] = "sensu"

--- a/recipes/_enterprise_repo.rb
+++ b/recipes/_enterprise_repo.rb
@@ -31,11 +31,13 @@ when "debian"
     action :add
   end
 else
-  repo = yum_repository "sensu-enterprise" do
-    description "sensu enterprise"
-    repo = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
-    url "#{repository_url}/#{repo}/noarch/"
-    action :add
+  { "sensu-enterprise" => "noarch", "sensu-enterprise-dashboard" => "$basearch" }.each_pair do |repo_name, arch|
+    repo = yum_repository repo_name do
+      description repo_name
+      channel = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
+      url "#{repository_url}/#{channel}/#{arch}/"
+      action :add
+    end
+    repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
   end
-  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
 end

--- a/test/cookbooks/sensu-test/recipes/enterprise_dashboard.rb
+++ b/test/cookbooks/sensu-test/recipes/enterprise_dashboard.rb
@@ -30,6 +30,7 @@ enterprise_hash = {
 set_sensu_state(node, "enterprise", enterprise_hash)
 
 include_recipe "sensu::enterprise_dashboard"
+include_recipe "sensu::enterprise_dashboard_service"
 
 # ServerSpec dependencies
 

--- a/test/integration/enterprise-dashboard/serverspec/enterprise-dashboard_spec.rb
+++ b/test/integration/enterprise-dashboard/serverspec/enterprise-dashboard_spec.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+
+describe service("sensu-enterprise-dashboard") do
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/unit/enterprise_repo.rb
+++ b/test/unit/enterprise_repo.rb
@@ -69,6 +69,13 @@ describe "sensu::_enterprise_repo" do
             :gpgcheck => false
           )
         end
+
+        it "creates sensu-enterprise-dashboard yum #{repo_designation} repository definition" do
+          expect(chef_run).to add_yum_repository("sensu-enterprise-dashboard").with(
+            :url => "http://chefspec:moartests!@enterprise.sensuapp.com/#{yum_repo_designation}/$basearch/",
+            :gpgcheck => false
+          )
+        end
       end
 
       context "using custom host with #{repo_designation} repo" do


### PR DESCRIPTION
## Description

On platforms using Yum for installing packages, this change adds a second repository definition for accessing Sensu Enterprise Dashboard packages matching the machine CPU architecture via yum `$basearch` variable.

## Motivation and Context

As described in #507, distributions like Centos are unable currently to install the `sensu-enterprise-dashboard` package using this cookbook because they are configured with a `noarch` repository URL which only provides `sensu-enterprise`.

Closes #507 

## How Has This Been Tested?

Added unit tests to cover the `$basearch` case, added serverspec tests for enterprise-dashboard integration suite.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.