### PR TITLE
Add :ignore_failure option to silence_check and silence_client definitions

### DIFF
--- a/definitions/silence_check.rb
+++ b/definitions/silence_check.rb
@@ -9,6 +9,7 @@ define :sensu_silence_check, :action => :create, :expire => nil, :payload => {} 
       api_uri params[:api_uri]
       expire params[:expire]
       payload params[:payload]
+      ignore_failure params[:ignore_failure]
       action :create
     end
   end
@@ -16,6 +17,7 @@ define :sensu_silence_check, :action => :create, :expire => nil, :payload => {} 
   if params[:action] == :delete or params[:action] == :unsilence
     sensu_api_stash "silence/#{params[:client]}/#{params[:name]}" do
       api_uri params[:api_uri]
+      ignore_failure params[:ignore_failure]
       action :delete
     end
   end

--- a/definitions/silence_client.rb
+++ b/definitions/silence_client.rb
@@ -4,6 +4,7 @@ define :sensu_silence_client, :action => :create, :expire => nil, :payload => {}
       api_uri params[:api_uri]
       expire params[:expire]
       payload params[:payload]
+      ignore_failure params[:ignore_failure]
       action :create
     end
   end
@@ -11,6 +12,7 @@ define :sensu_silence_client, :action => :create, :expire => nil, :payload => {}
   if params[:action] == :delete or params[:action] == :unsilence
     sensu_api_stash "silence/#{params[:name]}" do
       api_uri params[:api_uri]
+      ignore_failure params[:ignore_failure]
       action :delete
     end
   end


### PR DESCRIPTION
Add :ignore_failure option to silence_check and silence_client definitions
## Motivation and Context

Don't want the chef run to fail if the Sensu API server isn't available, as it may not exist or you are currently setting it up.
## How Has This Been Tested?

Tested in a lab env with no Sensu API server. Currently does not fail the chef run when it can't contact the server.
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
