### PR TITLE
[sensu_service] log deprecation warning when enabling embedded runsvdir

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -19,6 +19,11 @@ def sensu_runit_service_enabled?
 end
 
 def enable_sensu_runsvdir
+  log "sensu_embedded_runit_deprecated" do
+    message 'sensu.init_style "runit" is deprecated and will be removed in version 4.0 of this cookbook'
+    level :warn
+  end
+
   execute "configure_sensu_runsvdir_#{new_resource.service}" do
     command "#{sensu_ctl} configure"
     not_if "#{sensu_ctl} configured?"


### PR DESCRIPTION
## Description

This change adds a log message indicating that this feature is deprecated. We'll remove the embedded runit support in version 4.0 of this cookbook.

## Motivation and Context

As described in #515, Sensu 0.27 will remove the underlying support for the "runit" init_style.

Closes #515 

## How Has This Been Tested?

Testing test-kitchen runit suite, observed that the deprecation warning is logged:

```
* log[sensu_embedded_runit_deprecated] action write[2016-11-02T17:30:19+00:00] WARN: sensu.init_style "runit" is deprecated and will be removed in version 4.0 of this cookbook
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
