### PR TITLE
[enterprise_dashboard] use "1:" prefixed package version on debian

### DIFF
--- a/attributes/enterprise_dashboard.rb
+++ b/attributes/enterprise_dashboard.rb
@@ -2,7 +2,7 @@
 # "1:", which is not present on the rpm packages. As a result, we use the
 # platform_family to determine correct default version.
 #
-default["sensu"]["enterprise-dashboard"]["version"] = node['platform_family'] == 'debian' ? "1:1.4.0-1" : "1.4.0-1"
+default["sensu"]["enterprise-dashboard"]["version"] = node['platform_family'] == 'debian' ? "1:1.12.0-1" : "1.12.0-1"
 
 # data bag
 default["sensu"]["enterprise-dashboard"]["data_bag"]["name"] = "sensu"

--- a/attributes/enterprise_dashboard.rb
+++ b/attributes/enterprise_dashboard.rb
@@ -1,5 +1,8 @@
-# installation
-default["sensu"]["enterprise-dashboard"]["version"] = "1.4.0-1"
+# Due to a packaging error, debian versions are prefixed with an epoch, i.e.
+# "1:", which is not present on the rpm packages. As a result, we use the
+# platform_family to determine correct default version.
+#
+default["sensu"]["enterprise-dashboard"]["version"] = node['platform_family'] == 'debian' ? "1:1.4.0-1" : "1.4.0-1"
 
 # data bag
 default["sensu"]["enterprise-dashboard"]["data_bag"]["name"] = "sensu"


### PR DESCRIPTION
## Description

This change uses the platform_family attribute to ensure the epoch-prefixed version string is used by default on Debian platforms.

## Motivation and Context

Issue #512 indicates that the current default for the enterprise dashboard's version attribute does not work on Ubuntu.

Commit d4b37885c5bf016b5aec9a0fe59b97e0a204bc9f removed the epoch ("1:") prefix from default version of dashboard package. This is unsuitable for Debian platforms where dashboard package versions still contain this prefix.

Closes #512 

## How Has This Been Tested?
Tested centos and ubuntu `enterprise-dashboard` suites in test-kitchen

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.