### PR TITLE
replace emeril with stove

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 4.5"
-  gem "emeril", "~> 0.8"
+  gem "stove", "~> 4.1"
   gem "berkshelf", "= 4.3.0", "< 6.0"
   gem "rake"
   gem "guard"

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,13 @@
 #!/usr/bin/env rake
 
-# emeril helps us release the cookbook
-require 'emeril/rake_tasks'
-
 task default: [:spec]
 
-Emeril::RakeTasks.new do |t|
-  # disable git tag prefix string
-  t.config[:tag_prefix] = false
+# stove helps us ship the cookbook
+begin
+  require 'stove/rake_task'
+  Stove::RakeTask.new
+rescue LoadError
+  puts '>>>>> Stove gem not loaded, omitting tasks' unless ENV['CI']
 end
 
 # rspec runs unit tests


### PR DESCRIPTION
## Description

Replace emeril with [stove](https://github.com/sethvargo/stove).

## Motivation and Context

For reasons I have not been able to work around, emeril is no longer usable for releasing this (or maybe any?) cookbook.

Per recommendation of Chef folks, we're replacing emeril with stove. Known side-effect of this change is that tags will now be created with a 'v' prefix (e.g. 'v3.2.0', which breaks from the existing pattern. AFAICT this isn't configurable under stove.

## How Has This Been Tested?

Not yet tested as we aren't ready for a release. 😉 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.