### PR TITLE
Replaced hard coded sensu user in _windows.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "support@sensuapp.com"
 license          "Apache 2.0"
 description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.1.4"
+version          "3.1.3"
 
 # available @ https://supermarket.chef.io/cookbooks/apt
 depends "apt", ">= 2.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "support@sensuapp.com"
 license          "Apache 2.0"
 description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.1.3"
+version          "3.1.4"
 
 # available @ https://supermarket.chef.io/cookbooks/apt
 depends "apt", ">= 2.0"

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -19,13 +19,13 @@
 
 windows = node["sensu"]["windows"].dup
 
-user node["sensu"]["user"].to_s do
+user node["sensu"]["user"] do
   password Sensu::Helpers.random_password(20, true, true, true, true)
   not_if { Sensu::Helpers.windows_user_exists?(node["sensu"]["user"].to_s) }
 end
 
-group node["sensu"]["group"].to_s do
-  members node["sensu"]["user"].to_s
+group node["sensu"]["group"] do
+  members node["sensu"]["user"]
   action :manage
 end
 

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -21,7 +21,7 @@ windows = node["sensu"]["windows"].dup
 
 user node["sensu"]["user"] do
   password Sensu::Helpers.random_password(20, true, true, true, true)
-  not_if { Sensu::Helpers.windows_user_exists?(node["sensu"]["user"].to_s) }
+  not_if { Sensu::Helpers.windows_user_exists?(node["sensu"]["user"]) }
 end
 
 group node["sensu"]["group"] do

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -19,13 +19,13 @@
 
 windows = node["sensu"]["windows"].dup
 
-user "sensu" do
+user node["sensu"]["user"].to_s do
   password Sensu::Helpers.random_password(20, true, true, true, true)
-  not_if { Sensu::Helpers.windows_user_exists?("sensu") }
+  not_if { Sensu::Helpers.windows_user_exists?(node["sensu"]["user"].to_s) }
 end
 
-group "sensu" do
-  members "sensu"
+group node["sensu"]["group"].to_s do
+  members node["sensu"]["user"].to_s
   action :manage
 end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR closes #524 by replacing the hard coded "Sensu" user and group to be based off of the existing user and group attributes for the _windows recipe.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for the Windows platform to utilize the attributes vs. hard coded user and group names.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran tests to confirm that updates to the user and group are reflected in the converged test system in vagrant.  Ran kitchen verify for default-windows-2012-r2 only.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
