### PR TITLE
Extend template for sensu-enterprise defaults, manage heap dump path

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -97,6 +97,9 @@ suites:
       sensu_test:
         enterprise_repo_user: <%= ENV['SENSU_ENTERPRISE_USER'] %>
         enterprise_repo_pass: <%= ENV['SENSU_ENTERPRISE_PASS'] %>
+      sensu:
+        enterprise:
+          heap_dump_path: /var/cache/sensu-enterprise-nondefault
     run_list:
       - recipe[sensu-test::enterprise]
     excludes:

--- a/README.md
+++ b/README.md
@@ -261,7 +261,11 @@ Adjusting the value of `dotnet_major_version` attribute will influence which
 
 `node["sensu"]["enterprise"]["heap_size"]` - Configure Sensu Enterprise heap size
 
+`node["sensu"]["enterprise"]["heap_dump_path"]` - Configure path where Sensu Enterprise will store heap dumps. Directory path will be managed by Chef. Honored by Enterprise version 2.0.0 and newer.
+
 `node["sensu"]["enterprise"]["java_opts"]` - Specify additional Java options when running Sensu Enterprise
+
+`node["sensu"]["enterprise"]["max_open_files"]` - Specify maxiumum number of file handles. Honored by Enterprise version 1.7.2 and newer.
 
 ## Custom Resources (LWRPs)
 

--- a/attributes/enterprise.rb
+++ b/attributes/enterprise.rb
@@ -6,3 +6,5 @@ default["sensu"]["enterprise"]["use_unstable_repo"] = false
 default["sensu"]["enterprise"]["log_level"] = "info"
 default["sensu"]["enterprise"]["heap_size"] = "2048m"
 default["sensu"]["enterprise"]["java_opts"] = ""
+default["sensu"]["enterprise"]["max_open_files"] = 16384
+default["sensu"]["enterprise"]["heap_dump_path"] = "/var/cache/sensu-enterprise"

--- a/recipes/enterprise.rb
+++ b/recipes/enterprise.rb
@@ -24,6 +24,12 @@ package "sensu-enterprise" do
   version node["sensu"]["enterprise"]["version"]
 end
 
+directory node["sensu"]["enterprise"]["heap_dump_path"] do
+  owner node["sensu"]["user"]
+  group node["sensu"]["group"]
+  not_if { node["sensu"]["enterprise"]["heap_dump_path"] == "/tmp" }
+end
+
 template "/etc/default/sensu-enterprise" do
   source "sensu-enterprise.default.erb"
 end

--- a/templates/default/sensu-enterprise.default.erb
+++ b/templates/default/sensu-enterprise.default.erb
@@ -2,5 +2,7 @@ CONFIG_FILE=/etc/sensu/config.json
 CONFIG_DIR=/etc/sensu/conf.d
 PLUGINS_DIR=/etc/sensu/plugins
 LOG_LEVEL=<%= node["sensu"]["enterprise"]["log_level"] %>
+MAX_OPEN_FILES=<%= node["sensu"]["enterprise"]["max_open_files"].to_i %>
 HEAP_SIZE="<%= node["sensu"]["enterprise"]["heap_size"] %>"
+HEAP_DUMP_PATH="<%= node["sensu"]["enterprise"]["heap_dump_path"] %>"
 JAVA_OPTS="<%= node["sensu"]["enterprise"]["java_opts"] %>"

--- a/test/integration/enterprise/serverspec/enterprise_spec.rb
+++ b/test/integration/enterprise/serverspec/enterprise_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 require 'service_dependency_helper'
 
-describe file("/var/cache/sensu-enterprise") do
+describe file("/etc/default/sensu-enterprise") do
+  it { should exist }
+  its(:content) { should include('/var/cache/sensu-enterprise-nondefault') }
+end
+
+describe file("/var/cache/sensu-enterprise-nondefault") do
   it { should exist }
   it { should be_directory }
   it { should be_owned_by 'sensu' }

--- a/test/integration/enterprise/serverspec/enterprise_spec.rb
+++ b/test/integration/enterprise/serverspec/enterprise_spec.rb
@@ -1,6 +1,13 @@
 require 'spec_helper'
 require 'service_dependency_helper'
 
+describe file("/var/cache/sensu-enterprise") do
+  it { should exist }
+  it { should be_directory }
+  it { should be_owned_by 'sensu' }
+  it { should be_grouped_into 'sensu' }
+end
+
 describe service("sensu-enterprise") do
   it { should be_enabled }
   it { should be_running }


### PR DESCRIPTION
## Description

These changes add attributes for managing the`MAX_OPEN_FILES` and `HEAP_DUMP_PATH` environment variables written to /etc/default/sensu-enterprise. These settings are honored by Sensu Enterprise in versions 1.7.2 and 2.0.0, respectively.

## Motivation and Context

Closes https://github.com/sensu/sensu-chef/issues/511

## How Has This Been Tested?

Added integration test for management of heap dump directory. Existing integration tests pass.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.