### PR TITLE
Update default versions of Sensu and Sensu Enterprise

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,7 +17,12 @@ else
 end
 
 # installation
-default["sensu"]["version"] = "0.26.5-1"
+default["sensu"]["version"] = case node["platform_family"]
+                              when "windows", "aix"
+                                "0.26.5-1"
+                              else
+                                "0.26.5-2"
+                              end
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true

--- a/attributes/enterprise.rb
+++ b/attributes/enterprise.rb
@@ -1,7 +1,7 @@
 # installation
 default["sensu"]["enterprise"]["repo_protocol"] = "http"
 default["sensu"]["enterprise"]["repo_host"] = "enterprise.sensuapp.com"
-default["sensu"]["enterprise"]["version"] = "1.14.9-1"
+default["sensu"]["enterprise"]["version"] = "1.14.10-1"
 default["sensu"]["enterprise"]["use_unstable_repo"] = false
 default["sensu"]["enterprise"]["log_level"] = "info"
 default["sensu"]["enterprise"]["heap_size"] = "2048m"


### PR DESCRIPTION
## Description

This change implements a case switch to determine the correct package version (Sensu version + package build iteration) for the running platform family, and updates the default version of Sensu Enterprise.

## Motivation and Context

Current value for `node['sensu']['version']` is not appropriate for all platforms, resulting in errors on Linux test suites.

Sensu Enterprise version 1.4.10 is the latest release prior to Sensu Enterprise 2.0.

## How Has This Been Tested?

Subset of Test Kitchen integration tests pass for Linux and Windows platforms.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.