### PR TITLE
Add support for 'when' filter attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,11 @@ end
 ```ruby
 sensu_filter "environment" do
   attributes(:client => {:environment => "development"})
+  days(
+    :all => [{ :begin => "05:00 PM", :end => "09:00 AM" }}],
+    :saturday => [{ :begin => "09:00 AM", :end => "05:00 PM" }],
+    :sunday => [{ :begin => "09:00 AM", :end => "05:00 PM" }]
+  )
   negate true
 end
 ```

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -6,8 +6,11 @@ end
 action :create do
   filter = Sensu::Helpers.select_attributes(
     new_resource,
-    %w[attributes negate]
+    %w(attributes negate days)
   )
+  if filter.keys.map(&:to_s).include?('days')
+    filter[:when] = { :days => (filter.delete(:days) || filter.delete('days')) }
+  end
 
   definition = {
     "filters" => {

--- a/resources/filter.rb
+++ b/resources/filter.rb
@@ -2,6 +2,7 @@ actions :create, :delete
 
 attribute :attributes, :kind_of => Hash, :required => true
 attribute :negate, :kind_of => [TrueClass, FalseClass]
+attribute :days, :kind_of => Hash
 
 def initialize(*args)
   super

--- a/test/cookbooks/sensu-test/recipes/filter_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/filter_lwrp.rb
@@ -1,0 +1,22 @@
+sensu_filter 'always' do
+  attributes(:check => { :timestamp => 'eval: true' })
+end
+
+sensu_filter 'never' do
+  attributes(:check => { :timestamp => 'eval: true' })
+  negate true
+end
+
+sensu_filter 'daytime' do
+  attributes(:check => { :timestamp => 'eval: true' })
+  days(:all => [{ :begin => '09:00 AM', :end => '05:00 PM' }])
+end
+
+sensu_filter 'nighttime' do
+  attributes('check' => { 'timestamp' => 'eval: true' })
+  days('all' => [{ 'begin' => '05:00 PM', 'end' => '09:00 AM' }])
+end
+
+sensu_filter 'delete_me' do
+  action :delete
+end

--- a/test/unit/lwrps/filter_spec.rb
+++ b/test/unit/lwrps/filter_spec.rb
@@ -1,0 +1,88 @@
+require_relative "../spec_helper"
+
+describe 'sensu_filter' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      :step_into => ['sensu_filter'],
+      :file_cache_path => '/tmp',
+      :platform => 'ubuntu',
+      :version => '14.04'
+    ).converge('sensu-test::filter_lwrp')
+  end
+
+  it 'defaults to action :create' do
+    %w(always never daytime nighttime).each do |f|
+      expect(chef_run).to create_sensu_filter(f)
+    end
+  end
+
+  context 'action :create' do
+    it 'creates the specified filter definition' do
+      f = '/etc/sensu/conf.d/filters/always.json'
+      expected = {
+        'filters' => {
+          'always' => { :attributes => { :check => { :timestamp => 'eval: true' } } }
+        }
+      }
+      expect(chef_run).to create_sensu_json_file(f).with(:content => expected)
+    end
+
+    context 'negate specified' do
+      it 'creates the specified filter definition' do
+        f = '/etc/sensu/conf.d/filters/never.json'
+        expected = {
+          'filters' => {
+            'never' => {
+              :attributes => { :check => { :timestamp => 'eval: true' } },
+              :negate => true
+            }
+          }
+        }
+        expect(chef_run).to create_sensu_json_file(f).with(:content => expected)
+      end
+    end
+
+    context 'days specified' do
+      context 'with symbol hash keys' do
+        it 'creates the specified filter definition' do
+          f = '/etc/sensu/conf.d/filters/daytime.json'
+          expected = {
+            'filters' => {
+              'daytime' => {
+                :attributes => { :check => { :timestamp => 'eval: true' } },
+                :when => { :days => { :all => [{ :begin => '09:00 AM', :end => '05:00 PM' }] } }
+              }
+            }
+          }
+          expect(chef_run).to create_sensu_json_file(f).with(:content => expected)
+        end
+      end
+
+      context 'with string hash keys' do
+        it 'creates the specified filter definition' do
+          f = '/etc/sensu/conf.d/filters/nighttime.json'
+          expected = {
+            'filters' => {
+              'nighttime' => {
+                :attributes => { 'check' => { 'timestamp' => 'eval: true' } },
+                :when => { :days => { 'all' => [{ 'begin' => '05:00 PM', 'end' => '09:00 AM' }] } }
+              }
+            }
+          }
+          expect(chef_run).to create_sensu_json_file(f).with(:content => expected)
+        end
+      end
+    end
+  end
+
+  context 'action :delete' do
+    it 'deletes the specified filter' do
+      expect(chef_run).to delete_sensu_filter('delete_me')
+    end
+
+    it 'deletes the specified filter definition' do
+      f = '/etc/sensu/conf.d/filters/delete_me.json'
+      expect(chef_run).to delete_sensu_json_file(f)
+    end
+  end
+end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Because 'when' is also a reserved keyword in Ruby, that can't be the
name of the new attribute on the filter resource. However, 'days' is the
only valid attribute within the 'when' scope, so that seemed a decent
option.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

There is currently no way to place data in the 'when' attribute scope of a filter other than using the sensu_json_file resource directly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

ChefSpec tests have been added and confirmed to pass.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.