### PR TITLE
Use `append` when managing group on Windows

### DIFF
--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -26,6 +26,7 @@ end
 
 group node["sensu"]["group"] do
   members node["sensu"]["user"]
+  append true
   action :manage
 end
 


### PR DESCRIPTION
## Description

This change updates the group resource defined in the `_windows` recipe to set the value of the `append` property to `true`.

## Motivation and Context

Per https://github.com/sensu/sensu-chef/issues/531, the `group` resource needs `append` set to `true` in order to be used successfully with the built-in "Administrator" group.

Closes #531

## How Has This Been Tested?

Existing integration tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.