### PR TITLE
[sensu_check] validate subscribers/standalone on create action only

### DIFF
--- a/resources/check.rb
+++ b/resources/check.rb
@@ -27,5 +27,7 @@ def after_created
     raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: name cannot contain spaces or special characters"
   end
 
-  raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: must either define subscribers, or has to be standalone." unless (subscribers || standalone)
+  if action == :create
+     raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: must either define subscribers, or has to be standalone." unless (subscribers || standalone)
+  end
 end

--- a/test/cookbooks/sensu-test/recipes/good_checks.rb
+++ b/test/cookbooks/sensu-test/recipes/good_checks.rb
@@ -1,4 +1,3 @@
-
 sensu_check "valid_standalone_check" do
   interval 20
   command 'true'
@@ -9,4 +8,8 @@ sensu_check "valid_pubsub_check" do
   interval 20
   command 'true'
   subscribers ['all']
+end
+
+sensu_check "removed_check" do
+  action :delete
 end

--- a/test/unit/check_spec.rb
+++ b/test/unit/check_spec.rb
@@ -15,6 +15,13 @@ describe 'sensu-test::good_checks' do
     expect(chef_run).to create_sensu_check("valid_pubsub_check").with(:subscribers => ['all'])
   end
 
+  it "deletes removed_check without specifying subscriptions/standalone" do
+    expect(chef_run).to delete_sensu_check("removed_check").with(
+      :subscribers => nil,
+      :standalone => nil
+    )
+  end
+
 end
 
 describe 'sensu-test::bad_check_name' do


### PR DESCRIPTION
## Description

This change introduces conditional logic to validate subscriptions or standalone settings on `sensu_check` resources only when the action is `:create`.

## Motivation and Context

Closes #536 

## How Has This Been Tested?

Added unit test coverage.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.