### PR TITLE
Set sensu user as owner of second-level config directories

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -48,7 +48,7 @@ end
   extensions
 ].each do |dir|
   directory File.join(node["sensu"]["directory"], dir) do
-    owner node["sensu"]["admin_user"]
+    owner node["sensu"]["user"]
     group node["sensu"]["group"]
     recursive true
     mode node["sensu"]["directory_mode"]


### PR DESCRIPTION
## Description

This change ensures that directory ownership enforced by this recipe
matches directory ownership defined in packages for Sensu 0.27 and
later.

## Motivation and Context

Closes #552

## How Has This Been Tested?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.