### PR TITLE
Fixed sensu-enterprise.default.erb

### DIFF
--- a/templates/default/sensu-enterprise.default.erb
+++ b/templates/default/sensu-enterprise.default.erb
@@ -1,5 +1,5 @@
 CONFIG_FILE=/etc/sensu/config.json
-CONFIG_DIR=/etc/sensu/conf.d
+CONFD_DIR=/etc/sensu/conf.d
 PLUGINS_DIR=/etc/sensu/plugins
 LOG_LEVEL=<%= node["sensu"]["enterprise"]["log_level"] %>
 MAX_OPEN_FILES=<%= node["sensu"]["enterprise"]["max_open_files"].to_i %>


### PR DESCRIPTION
This changes CONFIG_DIR to CONFD_DIR which is the value actually used by sensu-service script.
