### PR TITLE
Add attribute for overriding lsb codename in apt repo configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 group :develop do
   gem "chef", "~> 12.9"
-  gem "chefspec", "~> 4.5"
+  gem "chefspec", "~> 6.0"
   gem "stove", "~> 4.1"
   gem "berkshelf", "= 4.3.0", "< 6.0"
   gem "rake"

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Enables and starts Sensu Enterprise Dashboard.
 `node["sensu"]["use_unstable_repo"]` - If the build resides on the
 "unstable" repository.
 
+`node["sensu"]["apt_repo_codename"]` - Override LSB release codename
+detected by ohai for purposes of configuring the apt repository definition.
+
 `node["sensu"]["directory"]` - Sensu configuration directory.
 
 `node["sensu"]["log_directory"]` - Sensu log directory.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@ end
 # installation
 default["sensu"]["version"] = "0.28.4-1"
 default["sensu"]["version_suffix"] = nil
+default["sensu"]["apt_repo_codename"] = nil
 default["sensu"]["use_unstable_repo"] = false
 default["sensu"]["log_level"] = "info"
 default["sensu"]["use_ssl"] = true

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -26,7 +26,7 @@ when "debian"
   apt_repository "sensu" do
     uri node["sensu"]['apt_repo_url']
     key "#{node['sensu']['apt_repo_url']}/pubkey.gpg"
-    distribution node["lsb"]["codename"]
+    distribution node["sensu"]["apt_repo_codename"] || node["lsb"]["codename"]
     components node["sensu"]["use_unstable_repo"] ? ["unstable"] : ["main"]
     action :add
     only_if { node["sensu"]["add_repo"] }

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -24,7 +24,24 @@ describe "sensu::default" do
         expect(chef_run).to install_package('sensu')
       end
 
+      it "configures the apt repo definition with the default codename" do
+        expect(chef_run).to add_apt_repository("sensu").with(:distribution => "precise")
+      end
+
       it_behaves_like('sensu default recipe')
+
+      context "when overriding the apt repository codename" do
+        let(:chef_run) do
+          ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+            server.create_data_bag("sensu", ssl_data_bag_item)
+            node.set["sensu"]["apt_repo_codename"] = "dory"
+          end.converge(described_recipe)
+        end
+
+        it "configures the apt repo definition with the provided codename" do
+          expect(chef_run).to add_apt_repository("sensu").with(:distribution => "dory")
+        end
+      end
     end
 
     context "when running on aix" do


### PR DESCRIPTION
## Description

Adds an attribute for overriding the "codename" automatically detected by Ohai. This attribute allows the use of Sensu packages built for Ubuntu LTS releases to be used on non-LTS releases, e.g. `xenial` packages can be installed on `wily` and `yakkety` systems.

Also upgrades ChefSpec from ~> 4.0 to ~> 6.0, as was expedient to fix a bug with regard to `add_apt_repository` assertions.

## Motivation and Context

Solves problem described in https://github.com/sensu/sensu-omnibus/issues/162

## How Has This Been Tested?

Added unit tests, tested functionality in local test-kitchen with a yakkety (16.10) VM.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.