### PR TITLE
Update Berkshelf and sensu-plugins-chef versions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2.5
+  - 2.3
 before_install: gem install bundler -v 1.10.6

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 6.0"
   gem "stove", "~> 4.1"
-  gem "berkshelf", "= 4.3.0", "< 6.0"
+  gem "berkshelf", "~> 5.6"
   gem "rake"
   gem "guard"
   gem "guard-foodcritic"

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ group :develop do
   gem "chef", "~> 12.9"
   gem "chefspec", "~> 6.0"
   gem "stove", "~> 4.1"
-  gem "berkshelf", "~> 5.6"
+  gem "berkshelf", ">= 5.6.4", "< 6.0"
   gem "rake"
   gem "guard"
   gem "guard-foodcritic"

--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -10,7 +10,7 @@ end
 
 # ensure we pass the specified version
 sensu_gem 'sensu-plugins-chef' do
-  version '2.0.0'
+  version '3.0.1'
   action :install
 end
 

--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -10,7 +10,7 @@ end
 
 # ensure we pass the specified version
 sensu_gem 'sensu-plugins-chef' do
-  version '0.0.5'
+  version '2.0.0'
   action :install
 end
 

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -21,7 +21,7 @@ describe 'sensu_gem' do
 
     context 'version specified' do
       it 'installs the specified version of the gem package' do
-        expect(chef_run).to install_gem_package('sensu-plugins-chef').with(:version => '2.0.0')
+        expect(chef_run).to install_gem_package('sensu-plugins-chef').with(:version => '3.0.1')
       end
     end
 

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -21,7 +21,7 @@ describe 'sensu_gem' do
 
     context 'version specified' do
       it 'installs the specified version of the gem package' do
-        expect(chef_run).to install_gem_package('sensu-plugins-chef').with(:version => '0.0.5')
+        expect(chef_run).to install_gem_package('sensu-plugins-chef').with(:version => '2.0.0')
       end
     end
 


### PR DESCRIPTION
## Description

* Update Berkshelf gem to ~> 5.6
* Update sensu-plugins-chef gem to 2.0.0

## Motivation and Context

Current version of Berkshelf generates a lot of warnings (see https://github.com/berkshelf/berkshelf/issues/1669)

Current version of sensu-plugins-chef (installed in integration tests via sensu_test::gem_lwrp recipe) fails to install on Sensu 0.29 (Ruby 2.4) due to old version of ffi-yajl.

## How Has This Been Tested?

Integration and unit tests pass.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.