### PR TITLE
Fix attribute syntax for Chef 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 bundler_args: --without integration
 rvm:
-  - 2.2.5
+  - 2.3
 before_install: gem install bundler -v 1.10.6

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -93,7 +93,7 @@ if node["sensu"]["use_ssl"]
     sensitive true if respond_to?(:sensitive)
   end
 else
-  if node["sensu"]["rabbitmq"].port == 5671
+  if node["sensu"]["rabbitmq"]["port"] == 5671
     Chef::Log.warn("Setting Sensu RabbitMQ port to 5672 as you have disabled SSL.")
     node.override["sensu"]["rabbitmq"]["port"] = 5672
   end


### PR DESCRIPTION
## Description

Chef 13 no longer accepts node['foo'].bar for attributes, and needs
node['foo']['bar'] to be used instead. This change fixes the syntax that
would otherwise cause a chef run failure when use_ssl is set to false.

## Motivation and Context

This is needed when using Chef 13, and when you have ssl disabled.

## How Has This Been Tested?

Test kitchen including the sensu cookbook and the latest version of chef client (13.0.118). `node['sensu']['use_ssl']` was set to false. Before the change the chef run fails with `ERROR: undefined method `port' for #<Chef::Node::ImmutableMash:0x00000002ef0900>`, afterwards the chef run succeeds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.