### PR TITLE
[linux] add amazon to platform_family case statement

### DIFF
--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -44,7 +44,7 @@ when "debian"
     options package_options
     notifies :create, "ruby_block[sensu_service_trigger]"
   end
-when "rhel", "fedora"
+when "rhel", "fedora", "amazon"
   repo = yum_repository "sensu" do
     description "sensu monitoring"
     repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"


### PR DESCRIPTION
## Description

Adds `amazon` to case switch for RedHat derivatives in _linux recipe 

This should fix one source of issues reported by Amazon Linux users
under Chef 13+

## Motivation and Context

Per https://github.com/chef/ohai/pull/971 Amazon Linux is detected as
platform_family "amazon" starting with Ohai 13.0

Closes #558

Note that installation on Amazon Linux is still broken as described in #560, proposed fix for that issue is open in #565.

## How Has This Been Tested?

Not yet tested.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.