### PR TITLE
Test in ChefDK and update specs for new Fauxhai

### DIFF
--- a/.foodcritic
+++ b/.foodcritic
@@ -1,5 +1,4 @@
 ~FC015 # Consider converting definition to a Custom Resource
-~FC023 # Prefer conditional attributes
 ~FC059 # LWRP provider does not declare use_inline_resources
 
 # these should all get fixed

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ addons:
 # Don't `bundle install`
 install: echo "skip bundle install"
 
-branches:
-  only:
-    - master
-
 # Ensure we make ChefDK's Ruby the default
 before_script:
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,27 @@
-language: ruby
-bundler_args: --without integration
-rvm:
-  - 2.3
-before_install: gem install bundler -v 1.10.6
+
+dist: trusty
+sudo: false
+addons:
+  apt:
+    sources:
+      - chef-current-trusty
+    packages:
+      - chefdk
+
+# Don't `bundle install`
+install: echo "skip bundle install"
+
+branches:
+  only:
+    - master
+
+# Ensure we make ChefDK's Ruby the default
+before_script:
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)"
+
+script:
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/foodcritic --version
+  - /opt/chefdk/bin/chef exec rake
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,27 +1,15 @@
+# This gemfile provides additional gems for testing and releasing this cookbook
+# It is meant to be installed on top of ChefDK which provides the majority
+# of the necessary gems for testing this cookbook
+#
+# Run 'chef exec bundle install' to install these dependencies
+
 source "https://rubygems.org"
 
-group :lint do
-  gem 'foodcritic', '~> 6.2'
-  gem 'rubocop', '~> 0.39.0'
-end
-
 group :develop do
-  gem "chef", "~> 12.9"
-  gem "chefspec", "~> 6.0"
-  gem "stove", "~> 4.1"
-  gem "berkshelf", ">= 5.6.4", "< 6.0"
-  gem "rake"
+  gem "stove", "~> 5.0"
   gem "guard"
   gem "guard-foodcritic"
   gem "guard-rspec"
   gem "guard-rubocop"
-end
-
-group :integration do
-  gem "test-kitchen", "~> 1.8"
-  gem "kitchen-docker"
-  gem "kitchen-vagrant"
-  gem "winrm", "~> 2.0"
-  gem "winrm-fs"
-  gem "winrm-elevated"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,15 @@ rescue LoadError
   puts '>>>>> Stove gem not loaded, omitting tasks' unless ENV['CI']
 end
 
+begin
+  require 'foodcritic'
+  FoodCritic::Rake::LintTask.new do |t|
+    t.options = { :tags => ['any'] }
+  end
+rescue LoadError
+  puts "foodcritic gem not found. Skipping"
+end
+
 # rspec runs unit tests
 begin
   require 'rspec/core/rake_task'

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ begin
     t.options = { :tags => ['any'] }
   end
 rescue LoadError
-  puts "foodcritic gem not found. Skipping"
+  puts ">>> Gem load error. Omitting #{task.name}" unless ENV['CI']
 end
 
 # rspec runs unit tests
@@ -32,6 +32,6 @@ end
 begin
   require 'kitchen/rake_tasks'
   Kitchen::RakeTasks.new
-rescue LoadError
-  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
+rescue StandardError => e
+  puts ">>> Gem load error: #{e}, omitting #{task.name}" unless ENV['CI']
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,7 @@
 name             "sensu"
 maintainer       "Heavy Water Operations"
 maintainer_email "support@sensuapp.com"
-license          "Apache 2.0"
+license          "Apache-2.0"
 description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "4.0.1"

--- a/test/cookbooks/sensu-test/metadata.rb
+++ b/test/cookbooks/sensu-test/metadata.rb
@@ -1,7 +1,7 @@
 name             "sensu-test"
 maintainer       "Sonian, Inc."
 maintainer_email "chefs@sonian.net"
-license          "Apache 2.0"
+license          "Apache-2.0"
 description      'Installs sensu stack for cookbook testing'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'

--- a/test/unit/client_service_spec.rb
+++ b/test/unit/client_service_spec.rb
@@ -2,31 +2,7 @@ require_relative "spec_helper"
 
 describe "sensu::client_service" do
   cached(:chef_run) do
-    ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
-      # allow(node).to receive(:chef_environment).and_return(env.name)
-      # server.create_environment(env.name, { description: "an environment for unit tests" })
-      # server.create_data_bag("sensu", sensu_data_bag)
-      # server.create_node(rabbitmq_node_name, rabbitmq_node_attrs)
-    end.converge(described_recipe)
-  end
-
-  it "enables the sensu-client service in ubuntu 12.04" do
-    expect(chef_run).to enable_sensu_service("sensu-client")
-  end
-
-  it "starts the sensu-client service in ubuntu 12.04" do
-    expect(chef_run).to start_sensu_service("sensu-client")
-  end
-end
-
-describe "sensu::client_service" do
-  cached(:chef_run) do
-    ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "14.04") do |node, server|
-      # allow(node).to receive(:chef_environment).and_return(env.name)
-      # server.create_environment(env.name, { description: "an environment for unit tests" })
-      # server.create_data_bag("sensu", sensu_data_bag)
-      # server.create_node(rabbitmq_node_name, rabbitmq_node_attrs)
-    end.converge(described_recipe)
+    ChefSpec::SoloRunner.new(:platform => "ubuntu", :version => "14.04").converge(described_recipe)
   end
 
   it "enables the sensu-client service in ubuntu 14.04" do
@@ -34,6 +10,20 @@ describe "sensu::client_service" do
   end
 
   it "starts the sensu-client service in ubuntu 14.04" do
+    expect(chef_run).to start_sensu_service("sensu-client")
+  end
+end
+
+describe "sensu::client_service" do
+  cached(:chef_run) do
+    ChefSpec::SoloRunner.new(:platform => "ubuntu", :version => "16.04").converge(described_recipe)
+  end
+
+  it "enables the sensu-client service in ubuntu 16.04" do
+    expect(chef_run).to enable_sensu_service("sensu-client")
+  end
+
+  it "starts the sensu-client service in ubuntu 16.04" do
     expect(chef_run).to start_sensu_service("sensu-client")
   end
 end

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -11,7 +11,7 @@ describe "sensu::default" do
 
     context "when running on ubuntu linux" do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
           server.create_data_bag("sensu", ssl_data_bag_item)
         end.converge(described_recipe)
       end
@@ -25,16 +25,16 @@ describe "sensu::default" do
       end
 
       it "configures the apt repo definition with the default codename" do
-        expect(chef_run).to add_apt_repository("sensu").with(:distribution => "precise")
+        expect(chef_run).to add_apt_repository("sensu").with(:distribution => "xenial")
       end
 
       it_behaves_like('sensu default recipe')
 
       context "when overriding the apt repository codename" do
         let(:chef_run) do
-          ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+          ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
             server.create_data_bag("sensu", ssl_data_bag_item)
-            node.set["sensu"]["apt_repo_codename"] = "dory"
+            node.override["sensu"]["apt_repo_codename"] = "dory"
           end.converge(described_recipe)
         end
 
@@ -72,7 +72,7 @@ describe "sensu::default" do
     let(:chef_run) do
       ChefSpec::ServerRunner.new(
         :platform => "windows",
-        :version => "2008R2"
+        :version => "2012R2"
       ) do |node, server|
         server.create_data_bag("sensu", ssl_data_bag_item)
         node.override["lsb"] = {}

--- a/test/unit/definitions/rabbitmq_credentials.rb
+++ b/test/unit/definitions/rabbitmq_credentials.rb
@@ -4,7 +4,7 @@ describe "sensu-test::rabbitmq_credentials" do
   let(:chef_run) do
     ChefSpec::ServerRunner.new(
       :platform => "ubuntu",
-      :version => "12.04"
+      :version => "16.04"
     ).converge(described_recipe)
   end
 

--- a/test/unit/enterprise_repo.rb
+++ b/test/unit/enterprise_repo.rb
@@ -17,7 +17,7 @@ describe "sensu::_enterprise_repo" do
   %w(stable unstable).each do |repo_designation|
     context "apt platforms" do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "12.04") do |node, server|
+        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
           node.override["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
           server.create_data_bag("sensu", data_bag_item)
         end.converge(described_recipe)

--- a/test/unit/spec_helper.rb
+++ b/test/unit/spec_helper.rb
@@ -1,8 +1,6 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-ChefSpec::Coverage.start!
-
 RSpec.shared_context('sensu data bags') do
   let(:ssl_data_bag_item) do
     # JSON.parse(


### PR DESCRIPTION
Test using ChefDK instead of a the Gemfile. Using gemfiles means you're either constantly working out a set of test deps that work on every platform / ruby version or you're just letting your test deps languish. Use ChefDK and you let Chef worry about the mess that is cross platform ruby deps. You get up to date versions of ChefSpec, Foodcritic, Test Kitchen, etc. This test environment also looks a lot more like a real chef environment with a matching ruby release.