### PR TITLE
Manage rabbitmq ssl directory permissions

### DIFF
--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -30,6 +30,7 @@ if node["sensu"]["use_ssl"]
   ssl_directory = "/etc/rabbitmq/ssl"
 
   directory ssl_directory do
+    mode '0755'
     recursive true
   end
 
@@ -57,7 +58,9 @@ if node["sensu"]["use_ssl"]
     node.override["rabbitmq"]["ssl_#{item}"] = path
   end
 
-  directory File.join(ssl_directory, "client")
+  directory File.join(ssl_directory, "client") do
+    mode '0755'
+  end
 
   %w[
     cert


### PR DESCRIPTION
## OS

- CentOS 6.9 (Santiago)

## Description

This change was necessary in my case because our systems have a default umask of `0027`. The RabbitMQ directories `/etc/rabbimq/ssl` and `/etc/rabbitmq/ssl/clients` are currently created using the system umask - defaulting to root/root ownership. The RabbitMQ server could not access the `ssl` or `clients` directories, required for it to run with certificates enabled.. This change resolves that problem.

## Motivation and Context

I experienced this issue, and there was no obvious solution. To help other people find this post, I had the following symptoms:

- The Sensu API at `localhost:4567` would respond with `redis and transport connections not initialized`.
- `/var/log/sensu/sensu-server.log` displays `transport connection closed` every few seconds in debug mode.
- `/var/log/sensu/sensu-api.log` responds to every request with a 500.

## How Has This Been Tested?

I have implemented this locally and it fixes the transport connection issue. Just to reiterate, everything else was setup properly besides the directory permissions.

I do not know if writing a test to check if RabbitMQ can access `/etc/rabbitmq/ssl/*` is within the scope of this cookbook.

## Types of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.