### PR TITLE
client.json should be owned by user instead of admin_user

### DIFF
--- a/providers/client.rb
+++ b/providers/client.rb
@@ -36,6 +36,7 @@ action :create do
 
   f = sensu_json_file ::File.join(node["sensu"]["directory"], "conf.d", "client.json") do
     content definition
+    owner node["sensu"]["user"]
   end
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Explicitly set ownership on client.json to sensu user instead of sensu admin_user. Addresses #571 

## Description
<!--- Describe your changes in detail -->
Updates providers/client.rb to set ownership on that file to sensu user. This should prevent the conf.d directory from incorrectly getting changed from user to admin_user as well.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Addresses #571 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verified in kitchen.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.