### PR TITLE
Added suse support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -27,6 +27,9 @@ depends "redisio", ">= 1.7.0"
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
 suggests "chef-vault", ">= 1.3.1"
 
+# available @ https://supermarket.chef.io/cookbooks/zypper
+suggests "zypper", ">= 0.4.0"
+
 %w[
   aix
   ubuntu
@@ -37,6 +40,7 @@ suggests "chef-vault", ">= 1.3.1"
   scientific
   oracle
   amazon
+  suse
   windows
 ].each do |os|
   supports os


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Redhat 7 packages for sensu and the corresponding repo works just fine with OpenSuSE 42.x and SLES 12.x.

## Motivation and Context
This fixes issue https://github.com/sensu/sensu-chef/issues/574

## How Has This Been Tested?
Tested with AMI ami-2af53a45 OpenSuse Leap 42.x
I used my chef-monitor cookbook to create a sensu client in OpenSuse

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.