### PR TITLE
Fix noisy Rubocop complaints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,11 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ### Features
 
-* When given a value, `node["sensu"]["yum_repo_releasever"]` attribute will be
+* When given a value, `node['sensu']['yum_repo_releasever']` attribute will be
 used in lieu of `$releasever` yum variable, restoring support for RHEL
 derivatives, e.g. Amazon Linux.
 
-* When given a value, `node["sensu"]["apt_repo_codename"]` attribute will be
+* When given a value, `node['sensu']['apt_repo_codename']` attribute will be
 used in lieu of the LSB codename detected by ohai on Debian and Ubuntu.
 
 ## [4.0.0] - 2017-03-14
@@ -88,7 +88,7 @@ The default version of Sensu Enterprise Dashboard is now 2.3.0
   `standalone` or `subscriptions` attributes
 
 * The built-in Administrator group should now be usable for the value
-  of `node["sensu"]["group"]` on Windows platforms.
+  of `node['sensu']['group']` on Windows platforms.
 
 ## [3.2.0] - 2017-01-10
 
@@ -117,7 +117,7 @@ The default version of Sensu Enterprise is now 1.14.10
 The default version of Sensu Enterprise Dashboard is now 1.12.0
 
 The account created for Sensu on Windows now uses the
-`node["sensu"]["user"]` attribute instead of a hard-coded value.
+`node['sensu']['user']` attribute instead of a hard-coded value.
 
 ### Project changes
 
@@ -154,7 +154,7 @@ Updated dependencies for yum, apt and windows cookbooks to make sense for Chef >
 
 Added support for AIX platform
 
-Added support for configuring SENSU_LOADED_TEMPFILE_DIR via `node["sensu"]["loaded_tempfile_dir"]`
+Added support for configuring SENSU_LOADED_TEMPFILE_DIR via `node['sensu']['loaded_tempfile_dir']`
 
 Added logic for detecting gem binary path on Windows platform
 
@@ -173,7 +173,7 @@ are not supported.
 
 The default version of Sensu installed by this cookbook is now 0.25.6-1.
 
-The default value of `node["sensu"]["use_embedded_ruby"]` is now `true`.
+The default value of `node['sensu']['use_embedded_ruby']` is now `true`.
 
 The `rabbitmq` recipe now installs Erlang via the Erlang Solutions repository on all platforms.
 
@@ -189,9 +189,9 @@ Sensu Enterprise JVM options are now configurable via attributes.
 
 Sensu transport `name` is now configurable via attributes.
 
-The `sensu_base_config` provider now honors `node["rabbitmq"]["hosts"]` attribute,
+The `sensu_base_config` provider now honors `node['rabbitmq']['hosts']` attribute,
 providing an array of hosts to use for configuring rabbitmq transport with multiple brokers.
-When `hosts` attribute has no value, we fall back to value of `node["sensu"]["rabbitmq"]["host"]`
+When `hosts` attribute has no value, we fall back to value of `node['sensu']['rabbitmq']['host']`
 attribute.
 
 The `sensu_client` provider now honors the following additional client
@@ -217,7 +217,7 @@ Expanded unit tests in many areas, including `sensu_base_config`,
 ### Fixes
 
 Directories created by the `sensu_json_file` provider now assume the mode
-defined by the value of `node["sensu"]["directory_mode"]` attribute.
+defined by the value of `node['sensu']['directory_mode']` attribute.
 
 The method used to look up `sensu_service_trigger` ruby block in the
 resource collection has been updated to eliminate conditions where Sensu

--- a/README.md
+++ b/README.md
@@ -171,48 +171,48 @@ Enables and starts Sensu Enterprise Dashboard.
 
 ### Installation
 
-`node["sensu"]["version"]` - Sensu build to install.
+`node['sensu']['version']` - Sensu build to install.
 
-`node["sensu"]["use_unstable_repo"]` - If the build resides on the
+`node['sensu']['use_unstable_repo']` - If the build resides on the
 "unstable" repository.
 
-`node["sensu"]["apt_repo_codename"]` - Override LSB release codename
+`node['sensu']['apt_repo_codename']` - Override LSB release codename
 detected by ohai for purposes of configuring the apt repository definition.
 
-`node["sensu"]["yum_repo_releasever"]` - Override `$releasever` string
+`node['sensu']['yum_repo_releasever']` - Override `$releasever` string
 used in yum repository definition.
 
 `node['sensu']['yum_flush_cache']` - Override chefs in memory cache of yum cache during a `chef-client` run. For more information see [here](https://docs.chef.io/resource_yum.html).
 
 `node["sensu"]["directory"]` - Sensu configuration directory.
 
-`node["sensu"]["log_directory"]` - Sensu log directory.
+`node['sensu']['log_directory']` - Sensu log directory.
 
-`node["sensu"]["log_level"]` - Sensu log level (eg. "warn").
+`node['sensu']['log_level']` - Sensu log level (eg. "warn").
 
-`node["sensu"]["use_ssl"]` - If Sensu and RabbitMQ are to use SSL.
+`node['sensu']['use_ssl']` - If Sensu and RabbitMQ are to use SSL.
 
-`node["sensu"]["user"]` - The user who owns all sensu files and directories. Default
+`node['sensu']['user']` - The user who owns all sensu files and directories. Default
 "sensu".
 
-`node["sensu"]["group"]` - The group that owns all sensu files and directories.
+`node['sensu']['group']` - The group that owns all sensu files and directories.
 Default "sensu".
 
-`node["sensu"]["use_embedded_ruby"]` - If Sensu Ruby handlers and plugins
+`node['sensu']['use_embedded_ruby']` - If Sensu Ruby handlers and plugins
 use the embedded Ruby in the Sensu package (default: true).
 
-`node["sensu"]["service_max_wait"]` - How long service scripts should wait
+`node['sensu']['service_max_wait']` - How long service scripts should wait
 for Sensu to start/stop.
 
-`node["sensu"]["loaded_tempfile_dir"]` - Where Sensu stores temporary files. Set a persistent directory if you use hardened system that cleans temporary directory regularly.
+`node['sensu']['loaded_tempfile_dir']` - Where Sensu stores temporary files. Set a persistent directory if you use hardened system that cleans temporary directory regularly.
 
 ### Windows
 
 Sensu requires Microsoft's .Net Framework to run on Windows. The following attributes influence the installation of .Net via this cookbook:
 
-`node["sensu"]["windows"]["install_dotnet"]` - Toggles installation of .Net Framework using ms_dotnet cookbook. (default: true)
+`node['sensu']['windows']['install_dotnet']` - Toggles installation of .Net Framework using ms_dotnet cookbook. (default: true)
 
-`node["sensu"]["windows"]["dotnet_major_version"]` - Major version of .Net Framework to install. (default: 4)
+`node['sensu']['windows']['dotnet_major_version']` - Major version of .Net Framework to install. (default: 4)
 
 Adjusting the value of `dotnet_major_version` attribute will influence which
  recipe from `ms_dotnet` cookbook will be included. See [`ms_dotnet` cookbook](https://github.com/criteo-cookbooks/ms_dotnet/blob/v2.6.1/README.md)
@@ -220,64 +220,64 @@ Adjusting the value of `dotnet_major_version` attribute will influence which
 
 ### Transport
 
-`node["sensu"]["transport"]["name"]` - Name of transport to use for Sensu communications. Default "rabbitmq"
+`node['sensu']['transport']['name']` - Name of transport to use for Sensu communications. Default "rabbitmq"
 
 ### RabbitMQ
 
-`node["sensu"]["rabbitmq"]["hosts"]` - Array of RabbitMQ hosts as strings, which will be combined with other RabbitMQ attributes to generate the Sensu RabbitMQ transport configuration as an array of hashes. Falls back to `node["sensu"]["rabbitmq"]["host"]` when empty. Defaults to an empty array.
+`node['sensu']['rabbitmq']['hosts']` - Array of RabbitMQ hosts as strings, which will be combined with other RabbitMQ attributes to generate the Sensu RabbitMQ transport configuration as an array of hashes. Falls back to `node['sensu']['rabbitmq']['host']` when empty. Defaults to an empty array.
 
-`node["sensu"]["rabbitmq"]["host"]` - RabbitMQ host.
+`node['sensu']['rabbitmq']['host']` - RabbitMQ host.
 
-`node["sensu"]["rabbitmq"]["port"]` - RabbitMQ port, usually for SSL.
+`node['sensu']['rabbitmq']['port']` - RabbitMQ port, usually for SSL.
 
-`node["sensu"]["rabbitmq"]["ssl"]` - RabbitMQ SSL configuration, DO NOT EDIT THIS.
+`node['sensu']['rabbitmq']['ssl']` - RabbitMQ SSL configuration, DO NOT EDIT THIS.
 
-`node["sensu"]["rabbitmq"]["vhost"]` - RabbitMQ vhost for Sensu.
+`node['sensu']['rabbitmq']['vhost']` - RabbitMQ vhost for Sensu.
 
-`node["sensu"]["rabbitmq"]["user"]` - RabbitMQ user for Sensu.
+`node['sensu']['rabbitmq']['user']` - RabbitMQ user for Sensu.
 
-`node["sensu"]["rabbitmq"]["password"]` - RabbitMQ password for Sensu.
+`node['sensu']['rabbitmq']['password']` - RabbitMQ password for Sensu.
 
 ### Redis
 
-`node["sensu"]["redis"]["host"]` - Redis host.
+`node['sensu']['redis']['host']` - Redis host.
 
-`node["sensu"]["redis"]["port"]` - Redis port.
+`node['sensu']['redis']['port']` - Redis port.
 
 ### Sensu API
 
-`node["sensu"]["api"]["host"]` - Sensu API host, for other services to reach it.
+`node['sensu']['api']['host']` - Sensu API host, for other services to reach it.
 
-`node["sensu"]["api"]["bind"]` - Sensu API bind address.
+`node['sensu']['api']['bind']` - Sensu API bind address.
 
-`node["sensu"]["api"]["port"]` - Sensu API port.
+`node['sensu']['api']['port']` - Sensu API port.
 
 ### Sensu Enterprise
 
-`node["sensu"]["enterprise"]["repo_protocol"]` - Sensu Enterprise repo protocol (e.g. http, https)
+`node['sensu']['enterprise']['repo_protocol']` - Sensu Enterprise repo protocol (e.g. http, https)
 
-`node["sensu"]["enterprise"]["repo_host"]` - Sensu Enterprise repo host
+`node['sensu']['enterprise']['repo_host']` - Sensu Enterprise repo host
 
-`node["sensu"]["enterprise"]["version"]` - Desired Sensu Enterprise package version
+`node['sensu']['enterprise']['version']` - Desired Sensu Enterprise package version
 
-`node["sensu"]["enterprise"]["use_unstable_repo"]` - Toggle use of Sensu Enterprise unstable repository
+`node['sensu']['enterprise']['use_unstable_repo']` - Toggle use of Sensu Enterprise unstable repository
 
-`node["sensu"]["enterprise"]["log_level"]` - Configure Sensu Enterprise log level
+`node['sensu']['enterprise']['log_level']` - Configure Sensu Enterprise log level
 
-`node["sensu"]["enterprise"]["heap_size"]` - Configure Sensu Enterprise heap size
+`node['sensu']['enterprise']['heap_size']` - Configure Sensu Enterprise heap size
 
-`node["sensu"]["enterprise"]["heap_dump_path"]` - Configure path where Sensu Enterprise will store heap dumps. Directory path will be managed by Chef. Honored by Enterprise version 2.0.0 and newer.
+`node['sensu']['enterprise']['heap_dump_path']` - Configure path where Sensu Enterprise will store heap dumps. Directory path will be managed by Chef. Honored by Enterprise version 2.0.0 and newer.
 
-`node["sensu"]["enterprise"]["java_opts"]` - Specify additional Java options when running Sensu Enterprise
+`node['sensu']['enterprise']['java_opts']` - Specify additional Java options when running Sensu Enterprise
 
-`node["sensu"]["enterprise"]["max_open_files"]` - Specify maxiumum number of file handles. Honored by Enterprise version 1.7.2 and newer.
+`node['sensu']['enterprise']['max_open_files']` - Specify maxiumum number of file handles. Honored by Enterprise version 1.7.2 and newer.
 
 ## Custom Resources (LWRPs)
 
 ### Define a client
 
 ```ruby
-sensu_client node["name"] do
+sensu_client node['name'] do
   address node["ipaddress"]
   subscriptions node["roles"] + ["all"]
   additional(:cluster => node["cluster"])
@@ -311,7 +311,7 @@ end
 sensu_check "redis_process" do
   command "check-procs.rb -p redis-server -C 1"
   handlers ["default"]
-  subscribers ["redis"]
+  subscribers ['redis']
   interval 30
   additional(:notification => "Redis is not running", :occurrences => 5)
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,67 +1,67 @@
 # user
-default["sensu"]["user"] = "sensu"
-default["sensu"]["group"] = "sensu"
+default['sensu']['user'] = 'sensu'
+default['sensu']['group'] = 'sensu'
 
 # platform
-if platform_family?("windows")
-  default["sensu"]["admin_user"] = "Administrator"
-  default["sensu"]["directory"] = 'C:\etc\sensu'
-  default["sensu"]["log_directory"] = 'C:\var\log\sensu'
-  default["sensu"]["windows"]["package_options"] = nil
-  default["sensu"]["windows"]["install_dotnet"] = true
-  default["sensu"]["windows"]["dotnet_major_version"] = 4
+if platform_family?('windows')
+  default['sensu']['admin_user'] = 'Administrator'
+  default['sensu']['directory'] = 'C:\etc\sensu'
+  default['sensu']['log_directory'] = 'C:\var\log\sensu'
+  default['sensu']['windows']['package_options'] = nil
+  default['sensu']['windows']['install_dotnet'] = true
+  default['sensu']['windows']['dotnet_major_version'] = 4
 else
-  default["sensu"]["admin_user"] = "root"
-  default["sensu"]["directory"] = "/etc/sensu"
-  default["sensu"]["log_directory"] = "/var/log/sensu"
+  default['sensu']['admin_user'] = 'root'
+  default['sensu']['directory'] = '/etc/sensu'
+  default['sensu']['log_directory'] = '/var/log/sensu'
 end
 
 # installation
-default["sensu"]["version"] = "0.28.4-1"
-default["sensu"]["version_suffix"] = nil
-default["sensu"]["apt_repo_codename"] = nil
-default["sensu"]["yum_repo_releasever"] = nil
-default["sensu"]["use_unstable_repo"] = false
-default["sensu"]["log_level"] = "info"
-default["sensu"]["use_ssl"] = true
-default["sensu"]["use_embedded_ruby"] = true
-default["sensu"]["service_max_wait"] = 10
-default["sensu"]["directory_mode"] = "0750"
-default["sensu"]["log_directory_mode"] = "0750"
-default["sensu"]["client_deregister_on_stop"] = false
-default["sensu"]["client_deregister_handler"] = nil
+default['sensu']['version'] = '0.28.4-1'
+default['sensu']['version_suffix'] = nil
+default['sensu']['apt_repo_codename'] = nil
+default['sensu']['yum_repo_releasever'] = nil
+default['sensu']['use_unstable_repo'] = false
+default['sensu']['log_level'] = 'info'
+default['sensu']['use_ssl'] = true
+default['sensu']['use_embedded_ruby'] = true
+default['sensu']['service_max_wait'] = 10
+default['sensu']['directory_mode'] = '0750'
+default['sensu']['log_directory_mode'] = '0750'
+default['sensu']['client_deregister_on_stop'] = false
+default['sensu']['client_deregister_handler'] = nil
 
-default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
-default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
+default['sensu']['apt_repo_url'] = 'http://repositories.sensuapp.org/apt'
+default['sensu']['yum_repo_url'] = 'http://repositories.sensuapp.org'
 default['sensu']['yum_flush_cache'] = nil
-default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
-default["sensu"]["aix_package_root_url"] = "https://sensu.global.ssl.fastly.net/aix"
-default["sensu"]["add_repo"] = true
+default['sensu']['msi_repo_url'] = 'http://repositories.sensuapp.org/msi'
+default['sensu']['aix_package_root_url'] = 'https://sensu.global.ssl.fastly.net/aix'
+default['sensu']['add_repo'] = true
 
 # transport
-default["sensu"]["transport"]["reconnect_on_error"] = true
-default["sensu"]["transport"]["name"] = 'rabbitmq'
+default['sensu']['transport']['reconnect_on_error'] = true
+default['sensu']['transport']['name'] = 'rabbitmq'
 
 # rabbitmq
-default["sensu"]["rabbitmq"]["hosts"] = []
-default["sensu"]["rabbitmq"]["host"] = "localhost"
-default["sensu"]["rabbitmq"]["port"] = 5671
-default["sensu"]["rabbitmq"]["vhost"] = "/sensu"
-default["sensu"]["rabbitmq"]["user"] = "sensu"
-default["sensu"]["rabbitmq"]["password"] = "password"
+default['sensu']['rabbitmq']['hosts'] = []
+default['sensu']['rabbitmq']['host'] = 'localhost'
+default['sensu']['rabbitmq']['port'] = 5671
+default['sensu']['rabbitmq']['vhost'] = '/sensu'
+default['sensu']['rabbitmq']['user'] = 'sensu'
+default['sensu']['rabbitmq']['password'] = 'password'
 
 # redis
-default["sensu"]["redis"]["host"] = "localhost"
-default["sensu"]["redis"]["port"] = 6379
-default["sensu"]["redis"]["reconnect_on_error"] = true
+default['sensu']['redis']['host'] = 'localhost'
+default['sensu']['redis']['port'] = 6379
+default['sensu']['redis']['reconnect_on_error'] = true
 
 # api
-default["sensu"]["api"]["host"] = "localhost"
-default["sensu"]["api"]["bind"] = "0.0.0.0"
-default["sensu"]["api"]["port"] = 4567
+default['sensu']['api']['host'] = 'localhost'
+default['sensu']['api']['bind'] = '0.0.0.0'
+default['sensu']['api']['port'] = 4567
 
 # data bag
-default["sensu"]["data_bag"]["name"] = "sensu"
-default["sensu"]["data_bag"]["ssl_item"] = "ssl"
-default["sensu"]["data_bag"]["config_item"] = "config"
-default["sensu"]["data_bag"]["enterprise_item"] = "enterprise"
+default['sensu']['data_bag']['name'] = 'sensu'
+default['sensu']['data_bag']['ssl_item'] = 'ssl'
+default['sensu']['data_bag']['config_item'] = 'config'
+default['sensu']['data_bag']['enterprise_item'] = 'enterprise'

--- a/attributes/enterprise.rb
+++ b/attributes/enterprise.rb
@@ -1,10 +1,10 @@
 # installation
-default["sensu"]["enterprise"]["repo_protocol"] = "http"
-default["sensu"]["enterprise"]["repo_host"] = "enterprise.sensuapp.com"
-default["sensu"]["enterprise"]["version"] = "2.5.1-1"
-default["sensu"]["enterprise"]["use_unstable_repo"] = false
-default["sensu"]["enterprise"]["log_level"] = "info"
-default["sensu"]["enterprise"]["heap_size"] = "2048m"
-default["sensu"]["enterprise"]["java_opts"] = ""
-default["sensu"]["enterprise"]["max_open_files"] = 16384
-default["sensu"]["enterprise"]["heap_dump_path"] = "/var/cache/sensu-enterprise"
+default['sensu']['enterprise']['repo_protocol'] = 'http'
+default['sensu']['enterprise']['repo_host'] = 'enterprise.sensuapp.com'
+default['sensu']['enterprise']['version'] = '2.5.1-1'
+default['sensu']['enterprise']['use_unstable_repo'] = false
+default['sensu']['enterprise']['log_level'] = 'info'
+default['sensu']['enterprise']['heap_size'] = '2048m'
+default['sensu']['enterprise']['java_opts'] = ''
+default['sensu']['enterprise']['max_open_files'] = 16_384
+default['sensu']['enterprise']['heap_dump_path'] = '/var/cache/sensu-enterprise'

--- a/attributes/enterprise_dashboard.rb
+++ b/attributes/enterprise_dashboard.rb
@@ -2,18 +2,18 @@
 # "1:", which is not present on the rpm packages. As a result, we use the
 # platform_family to determine correct default version.
 #
-default["sensu"]["enterprise-dashboard"]["version"] = node['platform_family'] == 'debian' ? "1:2.3.0-1" : "2.3.0-1"
+default['sensu']['enterprise-dashboard']['version'] = node['platform_family'] == 'debian' ? '1:2.3.0-1' : '2.3.0-1'
 
 # data bag
-default["sensu"]["enterprise-dashboard"]["data_bag"]["name"] = "sensu"
-default["sensu"]["enterprise-dashboard"]["data_bag"]["config_item"] = "enterprise_dashboard"
+default['sensu']['enterprise-dashboard']['data_bag']['name'] = 'sensu'
+default['sensu']['enterprise-dashboard']['data_bag']['config_item'] = 'enterprise_dashboard'
 
 # dashboard options
-default["sensu"]["enterprise-dashboard"]["dashboard"]["host"] = "0.0.0.0"
-default["sensu"]["enterprise-dashboard"]["dashboard"]["port"] = 3000
-default["sensu"]["enterprise-dashboard"]["dashboard"]["refresh"] = 5
-default["sensu"]["enterprise-dashboard"]["dashboard"]["user"] = "admin"
-default["sensu"]["enterprise-dashboard"]["dashboard"]["pass"] = "secret"
+default['sensu']['enterprise-dashboard']['dashboard']['host'] = '0.0.0.0'
+default['sensu']['enterprise-dashboard']['dashboard']['port'] = 3000
+default['sensu']['enterprise-dashboard']['dashboard']['refresh'] = 5
+default['sensu']['enterprise-dashboard']['dashboard']['user'] = 'admin'
+default['sensu']['enterprise-dashboard']['dashboard']['pass'] = 'secret'
 
 # sensu datacenters
-default["sensu"]["enterprise-dashboard"]["sensu"] = []
+default['sensu']['enterprise-dashboard']['sensu'] = []

--- a/libraries/sensu_run_state.rb
+++ b/libraries/sensu_run_state.rb
@@ -5,7 +5,7 @@ module Sensu
     #
     # @param node [Chef::Node] node object to mutate
     def init_sensu_state(node)
-      node.run_state["sensu"] ||= Mash.new
+      node.run_state['sensu'] ||= Mash.new
     end
 
     # Get value at given path
@@ -14,7 +14,7 @@ module Sensu
     # @param keys [String, Symbol] key path to walk
     def get_sensu_state(node, *keys)
       init_sensu_state(node)
-      keys.inject(node.run_state["sensu"]) do |memo,  key|
+      keys.inject(node.run_state['sensu']) do |memo,  key|
         if memo.is_a?(Hash) && Mash.new(memo).has_key?(key.to_s)
           memo[key]
         else
@@ -47,7 +47,7 @@ module Sensu
       real_value = value.is_a?(Chef::DataBagItem) ? value.to_hash.reject { |k,v| bag_item_headers.include?(k) } : value
 
       set_key = args.pop
-      leaf = args.inject(node.run_state["sensu"]) do |memo, key|
+      leaf = args.inject(node.run_state['sensu']) do |memo, key|
         unless memo[key].is_a?(Hash)
           memo[key] = Mash.new
         end

--- a/providers/api_stash.rb
+++ b/providers/api_stash.rb
@@ -11,14 +11,12 @@ action :create do
     # add path, timestamp and owner to the payload
     # when we look at the stash later, these bits helps us know how old a stash is and how it got there
     # allow to overwrite payload completely
-    payload = {'path' => new_resource.name, 'content' => { 'timestamp' => Time.now.to_i, 'owner' => 'chef'}}
+    payload = { 'path' => new_resource.name, 'content' => { 'timestamp' => Time.now.to_i, 'owner' => 'chef' } }
 
-    if new_resource.expire != nil
-      payload['expire'] = new_resource.expire
-    end
+    payload['expire'] = new_resource.expire unless new_resource.expire.nil?
 
     merged_payload = payload.merge(new_resource.payload)
-    if api.post("/stashes", merged_payload)
+    if api.post('/stashes', merged_payload)
       new_resource.updated_by_last_action(true)
     end
   end

--- a/providers/asset.rb
+++ b/providers/asset.rb
@@ -1,23 +1,23 @@
 def load_current_resource
-  @owner = new_resource.owner || node["sensu"]["admin_user"]
+  @owner = new_resource.owner || node['sensu']['admin_user']
 
   @uri = URI.parse(new_resource.name)
 
   asset_directory = case
-  when new_resource.asset_directory
-    new_resource.asset_directory
-  when new_resource.path
-    ::File.dirname(new_resource.path)
-  else
-    ::File.dirname(@uri.path)
-  end
+                    when new_resource.asset_directory
+                      new_resource.asset_directory
+                    when new_resource.path
+                      ::File.dirname(new_resource.path)
+                    else
+                      ::File.dirname(@uri.path)
+                    end
 
   @file_name = case
-  when new_resource.path
-    ::File.basename(new_resource.path)
-  else
-    ::File.basename(@uri.path)
-  end
+               when new_resource.path
+                 ::File.basename(new_resource.path)
+               else
+                 ::File.basename(@uri.path)
+               end
 
   @asset_path = ::File.join(asset_directory, @file_name)
 end
@@ -25,16 +25,16 @@ end
 def manage_sensu_asset(resource_action)
   if @uri.scheme.nil?
     local_source = case
-    when new_resource.source_directory
-      ::File.join(new_resource.source_directory, @file_name)
-    else
-      new_resource.source
-    end
+                   when new_resource.source_directory
+                     ::File.join(new_resource.source_directory, @file_name)
+                   else
+                     new_resource.source
+                   end
 
     f = cookbook_file @asset_path do
       cookbook new_resource.cookbook
       source local_source
-      mode  new_resource.mode
+      mode new_resource.mode
       owner @owner
       group new_resource.group
       rights new_resource.rights if new_resource.rights
@@ -44,7 +44,7 @@ def manage_sensu_asset(resource_action)
     f = remote_file @asset_path do
       source new_resource.name
       checksum new_resource.checksum
-      mode  new_resource.mode
+      mode new_resource.mode
       owner @owner
       group new_resource.group
       rights new_resource.rights if new_resource.rights
@@ -56,9 +56,9 @@ def manage_sensu_asset(resource_action)
 end
 
 [
- :create,
- :create_if_missing,
- :delete
+  :create,
+  :create_if_missing,
+  :delete
 ].each do |resource_action|
   action resource_action do
     manage_sensu_asset(resource_action)

--- a/providers/base_config.rb
+++ b/providers/base_config.rb
@@ -1,11 +1,11 @@
 action :create do
   definitions = Sensu::Helpers.select_attributes(
-    node["sensu"],
+    node['sensu'],
     %w[transport rabbitmq redis api]
   )
 
-  data_bag_name = node["sensu"]["data_bag"]["name"]
-  config_item = node["sensu"]["data_bag"]["config_item"]
+  data_bag_name = node['sensu']['data_bag']['name']
+  config_item = node['sensu']['data_bag']['config_item']
 
   config = Sensu::Helpers.data_bag_item(config_item, true, data_bag_name)
 
@@ -56,19 +56,19 @@ action :create do
   def generate_rabbitmq_array(definitions, hosts)
     hosts.map do |host|
       config = { "host" => host }
-      config.merge!(definitions["rabbitmq"].reject { |k| k == "host" || k == "hosts" })
+      config.merge!(definitions['rabbitmq'].reject { |k| k == "host" || k == "hosts" })
     end
   end
 
-  rabbitmq_config_array = if definitions["rabbitmq"]["hosts"].empty?
-                            generate_rabbitmq_array(definitions, [definitions["rabbitmq"]["host"]])
+  rabbitmq_config_array = if definitions['rabbitmq']['hosts'].empty?
+                            generate_rabbitmq_array(definitions, [definitions['rabbitmq']['host']])
                           else
-                            generate_rabbitmq_array(definitions, definitions["rabbitmq"]["hosts"])
+                            generate_rabbitmq_array(definitions, definitions['rabbitmq']['hosts'])
                           end
 
-  definitions["rabbitmq"] = rabbitmq_config_array
+  definitions['rabbitmq'] = rabbitmq_config_array
 
-  f = sensu_json_file ::File.join(node["sensu"]["directory"], "config.json") do
+  f = sensu_json_file ::File.join(node['sensu']['directory'], 'config.json') do
     content Sensu::Helpers.sanitize(definitions)
   end
 

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -1,5 +1,5 @@
 def load_current_resource
-  definition_directory = ::File.join(node["sensu"]["directory"], "conf.d", "checks")
+  definition_directory = ::File.join(node['sensu']['directory'], "conf.d", "checks")
   @definition_path = ::File.join(definition_directory, "#{new_resource.name}.json")
 end
 
@@ -13,14 +13,14 @@ action :create do
   # results. Currently this is only `interval`.
   check = Sensu::Helpers.select_attributes(
     new_resource,
-    %w[
+    %w(
       type command timeout subscribers standalone aggregate aggregates handle
       handlers publish subdue low_flap_threshold high_flap_threshold
-    ]
+    )
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 
   definition = {
-    "checks" => {
+    'checks' => {
       new_resource.name => Sensu::Helpers.sanitize(check)
     }
   }

--- a/providers/client.rb
+++ b/providers/client.rb
@@ -31,12 +31,12 @@ action :create do
   ).merge(new_resource.additional)
 
   definition = {
-    "client" => Sensu::Helpers.sanitize(client)
+    'client' => Sensu::Helpers.sanitize(client)
   }
 
-  f = sensu_json_file ::File.join(node["sensu"]["directory"], "conf.d", "client.json") do
+  f = sensu_json_file ::File.join(node['sensu']['directory'], "conf.d", "client.json") do
     content definition
-    owner node["sensu"]["user"]
+    owner node['sensu']['user']
   end
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)

--- a/providers/dashboard_config.rb
+++ b/providers/dashboard_config.rb
@@ -1,11 +1,11 @@
 action :create do
   definitions = Sensu::Helpers.select_attributes(
-    node["sensu"]["enterprise-dashboard"],
-    %w[dashboard sensu]
+    node['sensu']['enterprise-dashboard'],
+    %w(dashboard sensu)
   )
 
-  data_bag_name = node["sensu"]["enterprise-dashboard"]["data_bag"]["name"]
-  config_item = node["sensu"]["enterprise-dashboard"]["data_bag"]["config_item"]
+  data_bag_name = node['sensu']['enterprise-dashboard']['data_bag']['name']
+  config_item = node['sensu']['enterprise-dashboard']['data_bag']['config_item']
 
   config = Sensu::Helpers.data_bag_item(config_item, true, data_bag_name)
 
@@ -13,7 +13,7 @@ action :create do
     definitions = Chef::Mixin::DeepMerge.merge(definitions, config.to_hash)
   end
 
-  f = sensu_json_file ::File.join(node["sensu"]["directory"], "dashboard.json") do
+  f = sensu_json_file ::File.join(node['sensu']['directory'], 'dashboard.json') do
     content Sensu::Helpers.sanitize(definitions)
   end
 

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -1,5 +1,5 @@
 def load_current_resource
-  definition_directory = ::File.join(node["sensu"]["directory"], "conf.d", "filters")
+  definition_directory = ::File.join(node['sensu']['directory'], "conf.d", "filters")
   @definition_path = ::File.join(definition_directory, "#{new_resource.name}.json")
 end
 
@@ -13,7 +13,7 @@ action :create do
   end
 
   definition = {
-    "filters" => {
+    'filters' => {
       new_resource.name => Sensu::Helpers.sanitize(filter)
     }
   }

--- a/providers/gem.rb
+++ b/providers/gem.rb
@@ -2,7 +2,7 @@ action :install do
   g = gem_package new_resource.name do
     gem_binary Sensu::Helpers.gem_binary
     version new_resource.version
-    source  new_resource.source
+    source new_resource.source
     options new_resource.options
   end
 

--- a/providers/handler.rb
+++ b/providers/handler.rb
@@ -1,5 +1,5 @@
 def load_current_resource
-  definition_directory = ::File.join(node["sensu"]["directory"], "conf.d", "handlers")
+  definition_directory = ::File.join(node['sensu']['directory'], "conf.d", "handlers")
   @definition_path = ::File.join(definition_directory, "#{new_resource.name}.json")
 end
 
@@ -7,13 +7,20 @@ action :create do
   handler = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type filters mutator severities handlers
-      command timeout socket pipe
+      command
+      filters
+      handlers
+      mutator
+      pipe
+      severities
+      socket
+      timeout
+      type
     ]
   ).merge(new_resource.additional)
 
   definition = {
-    "handlers" => {
+    'handlers' => {
       new_resource.name => Sensu::Helpers.sanitize(handler)
     }
   }

--- a/providers/json_file.rb
+++ b/providers/json_file.rb
@@ -1,22 +1,22 @@
 action :create do
   sensu_service_trigger = !!run_context.resource_collection.detect do |r|
-    r.to_s == "ruby_block[sensu_service_trigger]"
+    r.to_s == 'ruby_block[sensu_service_trigger]'
   end
 
   directory "create_dir_for_#{new_resource.path}" do
     path ::File.dirname(new_resource.path)
     recursive true
-    owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
-    group lazy { new_resource.group || node["sensu"]["group"] }
-    mode lazy { node["sensu"]["directory_mode"] }
+    owner lazy { new_resource.owner || node['sensu']['admin_user'] }
+    group lazy { new_resource.group || node['sensu']['group'] }
+    mode lazy { node['sensu']['directory_mode'] }
   end
 
   f = file new_resource.path do
-    owner lazy { new_resource.owner || node["sensu"]["admin_user"] }
-    group lazy { new_resource.group || node["sensu"]["group"] }
+    owner lazy { new_resource.owner || node['sensu']['admin_user'] }
+    group lazy { new_resource.group || node['sensu']['group'] }
     mode new_resource.mode
     content Sensu::JSONFile.dump_json(new_resource.content)
-    notifies :create, "ruby_block[sensu_service_trigger]", :delayed if sensu_service_trigger
+    notifies :create, 'ruby_block[sensu_service_trigger]', :delayed if sensu_service_trigger
   end
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)
@@ -24,12 +24,12 @@ end
 
 action :delete do
   sensu_service_trigger = !!node.run_context.resource_collection.detect do |r|
-    r.to_s == "ruby_block[sensu_service_trigger]"
+    r.to_s == 'ruby_block[sensu_service_trigger]'
   end
 
   f = file new_resource.path do
     action :delete
-    notifies :create, "ruby_block[sensu_service_trigger]", :delayed if sensu_service_trigger
+    notifies :create, 'ruby_block[sensu_service_trigger]', :delayed if sensu_service_trigger
   end
 
   new_resource.updated_by_last_action(f.updated_by_last_action?)

--- a/providers/mutator.rb
+++ b/providers/mutator.rb
@@ -1,5 +1,5 @@
 def load_current_resource
-  definition_directory = ::File.join(node["sensu"]["directory"], "conf.d", "mutators")
+  definition_directory = ::File.join(node['sensu']['directory'], 'conf.d', 'mutators')
   @definition_path = ::File.join(definition_directory, "#{new_resource.name}.json")
 end
 

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -2,13 +2,20 @@ def manage_sensu_asset(resource_action)
   attributes = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      cookbook source source_directory checksum
-      path mode owner group rights
+      checksum
+      cookbook
+      group
+      mode
+      owner
+      path
+      rights
+      source
+      source_directory
     ]
   )
 
   a = sensu_asset new_resource.name do
-    asset_directory new_resource.asset_directory || ::File.join(node["sensu"]["directory"], "plugins")
+    asset_directory new_resource.asset_directory || ::File.join(node['sensu']['directory'], "plugins")
     attributes.each do |key, value|
       send(key.to_sym, value)
     end
@@ -19,9 +26,9 @@ def manage_sensu_asset(resource_action)
 end
 
 [
- :create,
- :create_if_missing,
- :delete
+  :create,
+  :create_if_missing,
+  :delete
 ].each do |resource_action|
   action resource_action do
     manage_sensu_asset(resource_action)

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -1,5 +1,5 @@
 def sensu_path
-  "/opt/sensu"
+  '/opt/sensu'
 end
 
 def load_current_resource
@@ -9,7 +9,7 @@ def load_current_resource
     retries 3
     retry_delay 5
     action :nothing
-    subscribes :restart, resources("ruby_block[sensu_service_trigger]"), :delayed
+    subscribes :restart, resources('ruby_block[sensu_service_trigger]'), :delayed
   end
 end
 

--- a/providers/snippet.rb
+++ b/providers/snippet.rb
@@ -1,5 +1,5 @@
 def load_current_resource
-  definition_directory = ::File.join(node["sensu"]["directory"], "conf.d")
+  definition_directory = ::File.join(node['sensu']['directory'], 'conf.d')
   @definition_path = ::File.join(definition_directory, "#{new_resource.name}.json")
 end
 

--- a/recipes/_aix.rb
+++ b/recipes/_aix.rb
@@ -20,14 +20,14 @@
 bff_path = File.join(Chef::Config[:file_cache_path], 'sensu.bff')
 
 remote_file bff_path do
-  source "#{node["sensu"]["aix_package_root_url"]}/sensu-#{node["sensu"]["version"]}.powerpc.bff"
+  source "#{node['sensu']['aix_package_root_url']}/sensu-#{node['sensu']['version']}.powerpc.bff"
 end
 
-package "sensu" do
+package 'sensu' do
   source bff_path
 end
 
-template "/etc/default/sensu" do
-  source "sensu.default.erb"
-  notifies :create, "ruby_block[sensu_service_trigger]"
+template '/etc/default/sensu' do
+  source 'sensu.default.erb'
+  notifies :create, 'ruby_block[sensu_service_trigger]'
 end

--- a/recipes/_enterprise_repo.rb
+++ b/recipes/_enterprise_repo.rb
@@ -1,40 +1,40 @@
-data_bag_name = node["sensu"]["data_bag"]["name"]
-enterprise_item = node["sensu"]["data_bag"]["enterprise_item"]
+data_bag_name = node['sensu']['data_bag']['name']
+enterprise_item = node['sensu']['data_bag']['enterprise_item']
 
 begin
-  unless get_sensu_state(node, "enterprise")
+  unless get_sensu_state(node, 'enterprise')
     enterprise = Sensu::Helpers.data_bag_item(enterprise_item, true, data_bag_name)
     set_sensu_state(node, "enterprise", enterprise)
-   end
+  end
 rescue => e
   Chef::Log.warn("Failed to populate Sensu state with Enterprise repository credentials from data bag: " + e.inspect)
 end
 
-credentials = get_sensu_state(node, "enterprise", "repository", "credentials")
+credentials = get_sensu_state(node, 'enterprise', 'repository', 'credentials')
 
 repository_url = case credentials.nil?
                  when true
-                   "#{node["sensu"]["enterprise"]["repo_protocol"]}://#{node["sensu"]["enterprise"]["repo_host"]}"
+                   "#{node['sensu']['enterprise']['repo_protocol']}://#{node['sensu']['enterprise']['repo_host']}"
                  when false
-                   "#{node["sensu"]["enterprise"]["repo_protocol"]}://#{credentials['user']}:#{credentials['password']}@#{node["sensu"]["enterprise"]["repo_host"]}"
+                   "#{node['sensu']['enterprise']['repo_protocol']}://#{credentials['user']}:#{credentials['password']}@#{node['sensu']['enterprise']['repo_host']}"
                  end
 
-case node["platform_family"]
-when "debian"
-  include_recipe "apt"
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt'
 
-  apt_repository "sensu-enterprise" do
-    uri File.join(repository_url, "apt")
-    key File.join(repository_url, "apt", "pubkey.gpg")
+  apt_repository 'sensu-enterprise' do
+    uri File.join(repository_url, 'apt')
+    key File.join(repository_url, 'apt', 'pubkey.gpg')
     distribution "sensu-enterprise"
-    components node["sensu"]["enterprise"]["use_unstable_repo"] ? ["unstable"] : ["main"]
+    components node['sensu']['enterprise']['use_unstable_repo'] ? ['unstable'] : ['main']
     action :add
   end
 else
-  { "sensu-enterprise" => "noarch", "sensu-enterprise-dashboard" => "$basearch" }.each_pair do |repo_name, arch|
+  { "sensu-enterprise" => 'noarch', 'sensu-enterprise-dashboard' => '$basearch' }.each_pair do |repo_name, arch|
     repo = yum_repository repo_name do
       description repo_name
-      channel = node["sensu"]["enterprise"]["use_unstable_repo"] ? "yum-unstable" : "yum"
+      channel = node['sensu']['enterprise']['use_unstable_repo'] ? 'yum-unstable' : 'yum'
       url "#{repository_url}/#{channel}/#{arch}/"
       action :add
     end

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -20,79 +20,83 @@
 platform_family = node["platform_family"]
 
 case platform_family
-when "debian"
-  include_recipe "apt"
+when 'debian'
+  include_recipe 'apt'
 
-  apt_repository "sensu" do
-    uri node["sensu"]['apt_repo_url']
+  apt_repository 'sensu' do
+    uri node['sensu']['apt_repo_url']
     key "#{node['sensu']['apt_repo_url']}/pubkey.gpg"
-    distribution node["sensu"]["apt_repo_codename"] || node["lsb"]["codename"]
-    components node["sensu"]["use_unstable_repo"] ? ["unstable"] : ["main"]
+    distribution node['sensu']['apt_repo_codename'] || node['lsb']['codename']
+    components node['sensu']['use_unstable_repo'] ? ['unstable'] : ['main']
     action :add
-    only_if { node["sensu"]["add_repo"] }
+    only_if { node['sensu']['add_repo'] }
   end
 
-  apt_preference "sensu" do
+  apt_preference 'sensu' do
     pin "version #{node['sensu']['version']}"
-    pin_priority "700"
+    pin_priority '700'
   end
 
   package_options = '--force-yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew"'
 
-  package "sensu" do
-    version node["sensu"]["version"]
+  package 'sensu' do
+    version node['sensu']['version']
     options package_options
-    notifies :create, "ruby_block[sensu_service_trigger]"
+    notifies :create, 'ruby_block[sensu_service_trigger]'
   end
-when "suse"
+when 'suse'
   repo = zypper_repo 'sensu' do
     repo_name 'sensu'
-    repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"
+    repo = node['sensu']['use_unstable_repo'] ? 'yum-unstable' : 'yum'
     uri "#{node['sensu']['yum_repo_url']}/#{repo}/7/x86_64/"
   end
 
   repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
 
   # As of 0.27 we need to suffix the version string with the platform major
-  # version, e.g. ".el7". Override default via node["sensu"]["version_suffix"]
+  # version, e.g. ".el7". Override default via node['sensu']['version_suffix']
   # attribute.
-  zypper_package "sensu" do
-    version lazy { "1:" + Sensu::Helpers.redhat_version_string(
-      node["sensu"]["version"],
-      7,
-      node["sensu"]["version_suffix"]
-    )}
-    notifies :create, "ruby_block[sensu_service_trigger]"
+  zypper_package 'sensu' do
+    version lazy {
+      '1:' + Sensu::Helpers.redhat_version_string(
+        node['sensu']['version'],
+        7,
+        node['sensu']['version_suffix']
+      )
+    }
+    notifies :create, 'ruby_block[sensu_service_trigger]'
   end
-when "rhel", "fedora", "amazon"
-  repo = yum_repository "sensu" do
-    description "sensu monitoring"
-    repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"
-    releasever_string = node["sensu"]["yum_repo_releasever"] || "$releasever"
+when 'rhel', 'fedora', 'amazon'
+  repo = yum_repository 'sensu' do
+    description 'sensu monitoring'
+    repo = node['sensu']['use_unstable_repo'] ? 'yum-unstable' : 'yum'
+    releasever_string = node['sensu']['yum_repo_releasever'] || '$releasever'
     baseurl "#{node['sensu']['yum_repo_url']}/#{repo}/#{releasever_string}/$basearch/"
     action :add
-    only_if { node["sensu"]["add_repo"] }
+    only_if { node['sensu']['add_repo'] }
   end
   repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
 
   # As of 0.27 we need to suffix the version string with the platform major
-  # version, e.g. ".el7". Override default via node["sensu"]["version_suffix"]
+  # version, e.g. ".el7". Override default via node['sensu']['version_suffix']
   # attribute.
-  yum_package "sensu" do
-    version lazy { Sensu::Helpers.redhat_version_string(
-      node["sensu"]["version"],
-      node["platform_version"],
-      node["sensu"]["version_suffix"]
-    )}
+  yum_package 'sensu' do
+    version lazy {
+      Sensu::Helpers.redhat_version_string(
+        node['sensu']['version'],
+        node['platform_version'],
+        node['sensu']['version_suffix']
+      )
+    }
     allow_downgrade true
     flush_cache node['sensu']['yum_flush_cache'] unless node['sensu']['yum_flush_cache'].nil?
-    notifies :create, "ruby_block[sensu_service_trigger]"
+    notifies :create, 'ruby_block[sensu_service_trigger]'
   end
 else
   raise "Unsupported Linux platform family #{platform_family}"
 end
 
-template "/etc/default/sensu" do
-  source "sensu.default.erb"
-  notifies :create, "ruby_block[sensu_service_trigger]"
+template '/etc/default/sensu' do
+  source 'sensu.default.erb'
+  notifies :create, 'ruby_block[sensu_service_trigger]'
 end

--- a/recipes/_windows.rb
+++ b/recipes/_windows.rb
@@ -17,37 +17,37 @@
 # limitations under the License.
 #
 
-windows = node["sensu"]["windows"].dup
+windows = node['sensu']['windows'].dup
 
-user node["sensu"]["user"] do
+user node['sensu']['user'] do
   password Sensu::Helpers.random_password(20, true, true, true, true)
-  not_if { Sensu::Helpers.windows_user_exists?(node["sensu"]["user"]) }
+  not_if { Sensu::Helpers.windows_user_exists?(node['sensu']['user']) }
 end
 
-group node["sensu"]["group"] do
-  members node["sensu"]["user"]
+group node['sensu']['group'] do
+  members node['sensu']['user']
   append true
   action :manage
 end
 
-if windows["install_dotnet"]
+if windows['install_dotnet']
   include_recipe "ms_dotnet::ms_dotnet#{windows['dotnet_major_version']}"
 end
 
-package "Sensu" do
+package 'Sensu' do
   source "#{node['sensu']['msi_repo_url']}/sensu-#{node['sensu']['version']}.msi"
-  options windows["package_options"]
-  version node["sensu"]["version"].tr("-", ".")
-  notifies :create, "ruby_block[sensu_service_trigger]", :immediately
+  options windows['package_options']
+  version node['sensu']['version'].tr('-', '.')
+  notifies :create, 'ruby_block[sensu_service_trigger]", :immediately'
 end
 
 template 'C:\opt\sensu\bin\sensu-client.xml' do
-  source "sensu.xml.erb"
-  variables :service => "sensu-client", :name => "Sensu Client"
-  notifies :create, "ruby_block[sensu_service_trigger]", :immediately
+  source 'sensu.xml.erb'
+  variables :service => 'sensu-client', :name => 'Sensu Client'
+  notifies :create, 'ruby_block[sensu_service_trigger]', :immediately
 end
 
-execute "sensu-client.exe install" do
+execute 'sensu-client.exe install' do
   cwd 'C:\opt\sensu\bin'
-  not_if { Sensu::Helpers.windows_service_exists?("sensu-client") }
+  not_if { Sensu::Helpers.windows_service_exists?('sensu-client') }
 end

--- a/recipes/api_service.rb
+++ b/recipes/api_service.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-sensu_service "sensu-api" do
+sensu_service 'sensu-api' do
   action [:enable, :start]
 end

--- a/recipes/client_service.rb
+++ b/recipes/client_service.rb
@@ -18,13 +18,12 @@
 #
 
 service_actions = case node['platform_family']
-when 'aix'
-  [:start]
-else
-  [:enable, :start]
-end
+                  when 'aix'
+                    [:start]
+                  else
+                    [:enable, :start]
+                  end
 
-
-sensu_service "sensu-client" do
+sensu_service 'sensu-client' do
   action service_actions
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-ruby_block "sensu_service_trigger" do
+ruby_block 'sensu_service_trigger' do
   block do
     # Sensu service action trigger for LWRPs.
     # This resource must be defined before the Sensu LWRPs can be used.
@@ -25,77 +25,77 @@ ruby_block "sensu_service_trigger" do
   action :nothing
 end
 
-case node["platform_family"]
-when "windows"
-  include_recipe "sensu::_windows"
-when "aix"
-  include_recipe "sensu::_aix"
+case node['platform_family']
+when 'windows'
+  include_recipe 'sensu::_windows'
+when 'aix'
+  include_recipe 'sensu::_aix'
 else
-  include_recipe "sensu::_linux"
+  include_recipe 'sensu::_linux'
 end
 
-directory node["sensu"]["log_directory"] do
-  owner node["sensu"]["user"]
-  group node["sensu"]["group"]
+directory node['sensu']['log_directory'] do
+  owner node['sensu']['user']
+  group node['sensu']['group']
   recursive true
-  mode node["sensu"]["log_directory_mode"]
+  mode node['sensu']['log_directory_mode']
 end
 
-%w[
+%w(
   conf.d
   plugins
   handlers
   extensions
-].each do |dir|
-  directory File.join(node["sensu"]["directory"], dir) do
-    owner node["sensu"]["user"]
-    group node["sensu"]["group"]
+).each do |dir|
+  directory File.join(node['sensu']['directory'], dir) do
+    owner node['sensu']['user']
+    group node['sensu']['group']
     recursive true
-    mode node["sensu"]["directory_mode"]
+    mode node['sensu']['directory_mode']
   end
 end
 
-if node["sensu"]["use_ssl"]
-  node.override["sensu"]["rabbitmq"]["ssl"] = Mash.new
-  node.override["sensu"]["rabbitmq"]["ssl"]["cert_chain_file"] = File.join(node["sensu"]["directory"], "ssl", "cert.pem")
-  node.override["sensu"]["rabbitmq"]["ssl"]["private_key_file"] = File.join(node["sensu"]["directory"], "ssl", "key.pem")
+if node['sensu']['use_ssl']
+  node.override['sensu']['rabbitmq']['ssl'] = Mash.new
+  node.override['sensu']['rabbitmq']['ssl']['cert_chain_file'] = File.join(node['sensu']['directory'], "ssl", "cert.pem")
+  node.override['sensu']['rabbitmq']['ssl']['private_key_file'] = File.join(node['sensu']['directory'], "ssl", "key.pem")
 
-  directory File.join(node["sensu"]["directory"], "ssl") do
-    owner node["sensu"]["admin_user"]
-    group node["sensu"]["group"]
+  directory File.join(node['sensu']['directory'], "ssl") do
+    owner node['sensu']['admin_user']
+    group node['sensu']['group']
     mode 0750
   end
 
-  data_bag_name = node["sensu"]["data_bag"]["name"]
-  ssl_item = node["sensu"]["data_bag"]["ssl_item"]
+  data_bag_name = node['sensu']['data_bag']['name']
+  ssl_item = node['sensu']['data_bag']['ssl_item']
 
   begin
-    unless get_sensu_state(node, "ssl")
+    unless get_sensu_state(node, 'ssl')
       ssl_data = Sensu::Helpers.data_bag_item(ssl_item, false, data_bag_name).to_hash
-      set_sensu_state(node, "ssl", ssl_data)
+      set_sensu_state(node, 'ssl', ssl_data)
     end
   rescue => e
-    Chef::Log.warn("Failed to populate Sensu state with ssl credentials from data bag: " + e.inspect)
+    Chef::Log.warn('Failed to populate Sensu state with ssl credentials from data bag: ' + e.inspect)
   end
 
-  file node["sensu"]["rabbitmq"]["ssl"]["cert_chain_file"] do
-    content lazy { get_sensu_state(node, "ssl", "client", "cert") }
-    owner node["sensu"]["admin_user"]
-    group node["sensu"]["group"]
+  file node['sensu']['rabbitmq']['ssl']['cert_chain_file'] do
+    content lazy { get_sensu_state(node, 'ssl', 'client', 'cert') }
+    owner node['sensu']['admin_user']
+    group node['sensu']['group']
     mode 0640
   end
 
-  file node["sensu"]["rabbitmq"]["ssl"]["private_key_file"] do
-    content lazy { get_sensu_state(node, "ssl", "client", "key") }
-    owner node["sensu"]["admin_user"]
-    group node["sensu"]["group"]
+  file node['sensu']['rabbitmq']['ssl']['private_key_file'] do
+    content lazy { get_sensu_state(node, 'ssl', 'client', 'key') }
+    owner node['sensu']['admin_user']
+    group node['sensu']['group']
     mode 0640
     sensitive true if respond_to?(:sensitive)
   end
 else
-  if node["sensu"]["rabbitmq"]["port"] == 5671
-    Chef::Log.warn("Setting Sensu RabbitMQ port to 5672 as you have disabled SSL.")
-    node.override["sensu"]["rabbitmq"]["port"] = 5672
+  if node['sensu']['rabbitmq']['port'] == 5671
+    Chef::Log.warn('Setting Sensu RabbitMQ port to 5672 as you have disabled SSL.')
+    node.override['sensu']['rabbitmq']['port'] = 5672
   end
 end
 

--- a/recipes/enterprise.rb
+++ b/recipes/enterprise.rb
@@ -17,19 +17,19 @@
 # limitations under the License.
 #
 
-include_recipe "sensu"
-include_recipe "sensu::_enterprise_repo"
+include_recipe 'sensu'
+include_recipe 'sensu::_enterprise_repo'
 
-package "sensu-enterprise" do
-  version node["sensu"]["enterprise"]["version"]
+package 'sensu-enterprise' do
+  version node['sensu']['enterprise']['version']
 end
 
-directory node["sensu"]["enterprise"]["heap_dump_path"] do
-  owner node["sensu"]["user"]
-  group node["sensu"]["group"]
-  not_if { node["sensu"]["enterprise"]["heap_dump_path"] == "/tmp" }
+directory node['sensu']['enterprise']['heap_dump_path'] do
+  owner node['sensu']['user']
+  group node['sensu']['group']
+  not_if { node['sensu']['enterprise']['heap_dump_path'] == '/tmp' }
 end
 
-template "/etc/default/sensu-enterprise" do
-  source "sensu-enterprise.default.erb"
+template '/etc/default/sensu-enterprise' do
+  source 'sensu-enterprise.default.erb'
 end

--- a/recipes/enterprise_dashboard.rb
+++ b/recipes/enterprise_dashboard.rb
@@ -17,10 +17,10 @@
 # limitations under the License.
 #
 
-include_recipe "sensu::_enterprise_repo"
+include_recipe 'sensu::_enterprise_repo'
 
-package "sensu-enterprise-dashboard" do
-  version node["sensu"]["enterprise-dashboard"]["version"]
+package 'sensu-enterprise-dashboard' do
+  version node['sensu']['enterprise-dashboard']['version']
 end
 
 sensu_dashboard_config node.name

--- a/recipes/enterprise_dashboard_service.rb
+++ b/recipes/enterprise_dashboard_service.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-service "sensu-enterprise-dashboard" do
-  subscribes :restart, resources("package[sensu-enterprise-dashboard]"), :delayed
+service 'sensu-enterprise-dashboard' do
+  subscribes :restart, resources('package[sensu-enterprise-dashboard]'), :delayed
   supports :status => true, :start => true, :stop => true, :restart => true, :reload => false
   action [:enable, :start]
 end

--- a/recipes/enterprise_service.rb
+++ b/recipes/enterprise_service.rb
@@ -17,10 +17,10 @@
 # limitations under the License.
 #
 
-service "sensu-enterprise" do
-  subscribes :restart, resources("package[sensu-enterprise]"), :immediately
-  subscribes :restart, resources("template[/etc/default/sensu-enterprise]"), :immediately
-  subscribes :reload, resources("ruby_block[sensu_service_trigger]"), :delayed
+service 'sensu-enterprise' do
+  subscribes :restart, resources('package[sensu-enterprise]'), :immediately
+  subscribes :restart, resources('template[/etc/default/sensu-enterprise]'), :immediately
+  subscribes :reload, resources('ruby_block[sensu_service_trigger]'), :delayed
   supports :status => true, :start => true, :stop => true, :restart => true, :reload => true
   action [:enable, :start]
 end

--- a/recipes/rabbitmq.rb
+++ b/recipes/rabbitmq.rb
@@ -17,15 +17,15 @@
 # limitations under the License.
 #
 
-data_bag_name = node["sensu"]["data_bag"]["name"]
+data_bag_name = node['sensu']['data_bag']['name']
 
-group "rabbitmq"
+group 'rabbitmq'
 
-if node["sensu"]["use_ssl"]
-  node.override["rabbitmq"]["ssl"] = true
-  node.override["rabbitmq"]["ssl_port"] = node["sensu"]["rabbitmq"]["port"]
-  node.override["rabbitmq"]["ssl_verify"] = "verify_peer"
-  node.override["rabbitmq"]["ssl_fail_if_no_peer_cert"] = true
+if node['sensu']['use_ssl']
+  node.override['rabbitmq']['ssl'] = true
+  node.override['rabbitmq']['ssl_port'] = node['sensu']['rabbitmq']['port']
+  node.override['rabbitmq']['ssl_verify'] = 'verify_peer'
+  node.override['rabbitmq']['ssl_fail_if_no_peer_cert'] = true
 
   ssl_directory = "/etc/rabbitmq/ssl"
 
@@ -35,41 +35,41 @@ if node["sensu"]["use_ssl"]
   end
 
   begin
-    unless get_sensu_state(node, "ssl")
-      ssl_item = node["sensu"]["data_bag"]["ssl_item"]
-      ssl = Sensu::Helpers.data_bag_item(ssl_item, false, data_bag_name)
+    unless get_sensu_state(node, 'ssl')
+      ssl_item = node['sensu']['data_bag']['ssl_item']
+      _ssl = Sensu::Helpers.data_bag_item(ssl_item, false, data_bag_name)
     end
   rescue => e
-    Chef::Log.warn("Failed to populate Sensu state with ssl credentials from data bag: " + e.inspect)
+    Chef::Log.warn('Failed to populate Sensu state with ssl credentials from data bag: ' + e.inspect)
   end
 
-  %w[
+  %w(
     cacert
     cert
     key
-  ].each do |item|
+  ).each do |item|
     path = File.join(ssl_directory, "#{item}.pem")
     file path do
-      content lazy { get_sensu_state(node, "ssl", "server", item) }
-      group "rabbitmq"
+      content lazy { get_sensu_state(node, 'ssl', 'server', item) }
+      group 'rabbitmq'
       mode 0640
       sensitive true if respond_to?(:sensitive)
     end
-    node.override["rabbitmq"]["ssl_#{item}"] = path
+    node.override['rabbitmq']["ssl_#{item}"] = path
   end
 
-  directory File.join(ssl_directory, "client") do
+  directory File.join(ssl_directory, 'client') do
     mode '0755'
   end
 
-  %w[
+  %w(
     cert
     key
-  ].each do |item|
-    path = File.join(ssl_directory, "client", "#{item}.pem")
+  ).each do |item|
+    path = File.join(ssl_directory, 'client', "#{item}.pem")
     file path do
-      content lazy { get_sensu_state(node, "ssl", "client", item) }
-      group "rabbitmq"
+      content lazy { get_sensu_state(node, 'ssl', 'client', item) }
+      group 'rabbitmq'
       mode 0640
       sensitive true if respond_to?(:sensitive)
     end
@@ -77,48 +77,48 @@ if node["sensu"]["use_ssl"]
 end
 
 # Sensu recommends Erlang Solutions' erlang runtime distribution
-node.override["erlang"]["install_method"] = "esl"
+node.override['erlang']['install_method'] = 'esl'
 
-include_recipe "rabbitmq"
-include_recipe "rabbitmq::mgmt_console"
+include_recipe 'rabbitmq'
+include_recipe 'rabbitmq::mgmt_console'
 
-service "restart #{node["rabbitmq"]["service_name"]}" do
-  service_name node["rabbitmq"]["service_name"]
+service "restart #{node['rabbitmq']['service_name']}" do
+  service_name node['rabbitmq']['service_name']
   action :nothing
   subscribes :restart, resources("template[#{node['rabbitmq']['config_root']}/rabbitmq.config]"), :immediately
 end
 
-rabbitmq = node["sensu"]["rabbitmq"].to_hash
+rabbitmq = node['sensu']['rabbitmq'].to_hash
 
-config_item = node["sensu"]["data_bag"]["config_item"]
+config_item = node['sensu']['data_bag']['config_item']
 sensu_config = Sensu::Helpers.data_bag_item(config_item, true, data_bag_name)
 
-if sensu_config && sensu_config["rabbitmq"].is_a?(Hash)
-  rabbitmq = Chef::Mixin::DeepMerge.merge(rabbitmq, sensu_config["rabbitmq"])
+if sensu_config && sensu_config['rabbitmq'].is_a?(Hash)
+  rabbitmq = Chef::Mixin::DeepMerge.merge(rabbitmq, sensu_config['rabbitmq'])
 end
 
-rabbitmq_credentials "general" do
-  vhost rabbitmq["vhost"]
-  user rabbitmq["user"]
-  password rabbitmq["password"]
-  permissions rabbitmq["permissions"]
+rabbitmq_credentials 'general' do
+  vhost rabbitmq['vhost']
+  user rabbitmq['user']
+  password rabbitmq['password']
+  permissions rabbitmq['permissions']
 end
 
-%w[
+%w(
   client
   api
   server
-].each do |service|
+).each do |service|
   service_config = Sensu::Helpers.data_bag_item(service, true, data_bag_name)
 
-  next unless service_config && service_config["rabbitmq"].is_a?(Hash)
+  next unless service_config && service_config['rabbitmq'].is_a?(Hash)
 
-  service_rabbitmq = Chef::Mixin::DeepMerge.merge(rabbitmq, service_config["rabbitmq"])
+  service_rabbitmq = Chef::Mixin::DeepMerge.merge(rabbitmq, service_config['rabbitmq'])
 
   rabbitmq_credentials service do
-    vhost service_rabbitmq["vhost"]
-    user service_rabbitmq["user"]
-    password service_rabbitmq["password"]
-    permissions service_rabbitmq["permissions"]
+    vhost service_rabbitmq['vhost']
+    user service_rabbitmq['user']
+    password service_rabbitmq['password']
+    permissions service_rabbitmq['permissions']
   end
 end

--- a/recipes/redis.rb
+++ b/recipes/redis.rb
@@ -17,8 +17,8 @@
 # limitations under the License.
 #
 
-node.override["redisio"]["servers"] = [{:port => node["sensu"]["redis"]["port"]}]
+node.override['redisio']['servers'] = [{ :port => node['sensu']['redis']['port'] }]
 
-include_recipe "redisio::default"
-include_recipe "redisio::install"
-include_recipe "redisio::enable"
+include_recipe 'redisio::default'
+include_recipe 'redisio::install'
+include_recipe 'redisio::enable'

--- a/recipes/server_service.rb
+++ b/recipes/server_service.rb
@@ -17,6 +17,6 @@
 # limitations under the License.
 #
 
-sensu_service "sensu-server" do
+sensu_service 'sensu-server' do
   action [:enable, :start]
 end

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -2,7 +2,7 @@ actions :create, :delete
 default_action :create
 
 # 'standard' and 'status' types are synonymous
-attribute :type, :kind_of => String, :equal_to => %w[standard status metric]
+attribute :type, :kind_of => String, :equal_to => %w(standard status metric)
 attribute :command, :kind_of => String, :required => true
 attribute :timeout, :kind_of => Integer
 attribute :subscribers, :kind_of => Array
@@ -20,10 +20,10 @@ attribute :additional, :kind_of => Hash, :default => Hash.new
 
 def after_created
   unless name =~ /^[\w\.-]+$/
-    raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: name cannot contain spaces or special characters"
+    fail Chef::Exceptions::ValidationFailed, "Sensu check #{name}: name cannot contain spaces or special characters"
   end
 
   if [action].compact.flatten.include?(:create)
-     raise Chef::Exceptions::ValidationFailed, "Sensu check #{name}: must either define subscribers, or has to be standalone." unless (subscribers || standalone)
+    fail Chef::Exceptions::ValidationFailed, "Sensu check #{name}: must either define subscribers, or has to be standalone." unless (subscribers || standalone)
   end
 end

--- a/resources/client.rb
+++ b/resources/client.rb
@@ -14,5 +14,5 @@ attribute :deregistration, :kind_of => Hash, :default => {}
 attribute :additional, :kind_of => Hash, :default => {}
 
 def after_created
-  raise Chef::Exceptions::ValidationFailed, "Sensu client name cannot contain spaces or special characters" unless name =~ /^[\w\.-]+$/
+  fail Chef::Exceptions::ValidationFailed, 'Sensu client name cannot contain spaces or special characters' unless name =~ /^[\w\.-]+$/
 end

--- a/resources/handler.rb
+++ b/resources/handler.rb
@@ -1,7 +1,7 @@
 actions :create, :delete
 default_action :create
 
-attribute :type, :kind_of => String, :equal_to => %w[set pipe tcp udp transport]
+attribute :type, :kind_of => String, :equal_to => %w(set pipe tcp udp transport)
 attribute :filters, :kind_of => Array
 attribute :mutator, :kind_of => String
 attribute :severities, :kind_of => Array

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -1,4 +1,4 @@
 actions :enable, :disable, :start, :stop, :restart
 default_action :enable
 
-attribute :service, :name_attribute => true, :kind_of => String, :required => true, :equal_to => %w[sensu-server sensu-client sensu-api sensu-enterprise]
+attribute :service, :name_attribute => true, :kind_of => String, :required => true, :equal_to => %w(sensu-server sensu-client sensu-api sensu-enterprise)

--- a/templates/default/sensu-enterprise.default.erb
+++ b/templates/default/sensu-enterprise.default.erb
@@ -1,8 +1,8 @@
 CONFIG_FILE=/etc/sensu/config.json
 CONFIG_DIR=/etc/sensu/conf.d
 PLUGINS_DIR=/etc/sensu/plugins
-LOG_LEVEL=<%= node["sensu"]["enterprise"]["log_level"] %>
-MAX_OPEN_FILES=<%= node["sensu"]["enterprise"]["max_open_files"].to_i %>
-HEAP_SIZE="<%= node["sensu"]["enterprise"]["heap_size"] %>"
-HEAP_DUMP_PATH="<%= node["sensu"]["enterprise"]["heap_dump_path"] %>"
-JAVA_OPTS="<%= node["sensu"]["enterprise"]["java_opts"] %>"
+LOG_LEVEL=<%= node['sensu']['enterprise']['log_level'] %>
+MAX_OPEN_FILES=<%= node['sensu']['enterprise']['max_open_files'].to_i %>
+HEAP_SIZE="<%= node['sensu']['enterprise']['heap_size'] %>"
+HEAP_DUMP_PATH="<%= node['sensu']['enterprise']['heap_dump_path'] %>"
+JAVA_OPTS="<%= node['sensu']['enterprise']['java_opts'] %>"

--- a/templates/default/sensu.default.erb
+++ b/templates/default/sensu.default.erb
@@ -1,7 +1,7 @@
-EMBEDDED_RUBY=<%= node["sensu"]["use_embedded_ruby"] %>
-LOG_DIR=<%= node["sensu"]["log_directory"] %>
-LOG_LEVEL=<%= node["sensu"]["log_level"] %>
-SERVICE_MAX_WAIT=<%= node["sensu"]["service_max_wait"] %>
-CLIENT_DEREGISTER_ON_STOP=<%= node["sensu"]["client_deregister_on_stop"] %>
-<%= node["sensu"]["client_deregister_handler"] ? %|CLIENT_DEREGISTER_HANDLER=#{node["sensu"]["client_deregister_handler"]}| : nil %>
-<%= node["sensu"]["loaded_tempfile_dir"] ? %|export SENSU_LOADED_TEMPFILE_DIR=#{node["sensu"]["loaded_tempfile_dir"]}| : nil %>
+EMBEDDED_RUBY=<%= node['sensu']['use_embedded_ruby'] %>
+LOG_DIR=<%= node['sensu']['log_directory'] %>
+LOG_LEVEL=<%= node['sensu']['log_level'] %>
+SERVICE_MAX_WAIT=<%= node['sensu']['service_max_wait'] %>
+CLIENT_DEREGISTER_ON_STOP=<%= node['sensu']['client_deregister_on_stop'] %>
+<%= node['sensu']['client_deregister_handler'] ? %|CLIENT_DEREGISTER_HANDLER=#{node['sensu']['client_deregister_handler']}| : nil %>
+<%= node['sensu']['loaded_tempfile_dir'] ? %|export SENSU_LOADED_TEMPFILE_DIR=#{node['sensu']['loaded_tempfile_dir']}| : nil %>

--- a/templates/default/sensu.xml.erb
+++ b/templates/default/sensu.xml.erb
@@ -9,13 +9,13 @@
   <executable>C:\opt\sensu\embedded\bin\ruby</executable>
   <argument>C:\opt\sensu\embedded\bin\<%= @service %></argument>
   <argument>-c</argument>
-  <argument><%= node["sensu"]["directory"] %>\config.json</argument>
+  <argument><%= node['sensu']['directory'] %>\config.json</argument>
   <argument>-d</argument>
-  <argument><%= node["sensu"]["directory"] %>\conf.d</argument>
+  <argument><%= node['sensu']['directory'] %>\conf.d</argument>
   <argument>-e</argument>
-  <argument><%= node["sensu"]["directory"] %>\extensions</argument>
+  <argument><%= node['sensu']['directory'] %>\extensions</argument>
   <argument>-l</argument>
-  <argument><%= node["sensu"]["log_directory"] %>\<%= @service %>.log</argument>
+  <argument><%= node['sensu']['log_directory'] %>\<%= @service %>.log</argument>
   <argument>-L</argument>
-  <argument><%= node["sensu"]["log_level"] %></argument>
+  <argument><%= node['sensu']['log_level'] %></argument>
 </service>

--- a/test/cookbooks/sensu-test/metadata.rb
+++ b/test/cookbooks/sensu-test/metadata.rb
@@ -1,12 +1,11 @@
-name             "sensu-test"
-maintainer       "Sonian, Inc."
+name "sensu-test"
+maintainer "Sonian, Inc."
 maintainer_email "chefs@sonian.net"
-license          "Apache-2.0"
-description      'Installs sensu stack for cookbook testing'
+license "Apache-2.0"
+description 'Installs sensu stack for cookbook testing'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
-
-depends          'logrotate'
-depends          'sensu'
-depends          'chef-vault'
-depends          'build-essential'
+version '0.1.0'
+depends 'logrotate'
+depends 'sensu'
+depends 'chef-vault'
+depends 'build-essential'

--- a/test/cookbooks/sensu-test/recipes/asset.rb
+++ b/test/cookbooks/sensu-test/recipes/asset.rb
@@ -41,7 +41,7 @@ end
 
 profiler_extension = case platform?('windows')
                      when true
-                        "https://raw.githubusercontent.com/sensu/sensu-community-plugins/36ffb8b92c69065e7e5351a8011497e2c4ffd0e1/extensions/checks/wmi_metrics.rb"
+                       "https://raw.githubusercontent.com/sensu/sensu-community-plugins/36ffb8b92c69065e7e5351a8011497e2c4ffd0e1/extensions/checks/wmi_metrics.rb"
                      when false
                        "https://raw.githubusercontent.com/sensu/sensu-community-plugins/36ffb8b92c69065e7e5351a8011497e2c4ffd0e1/extensions/checks/system_profile.rb"
                      end

--- a/test/cookbooks/sensu-test/recipes/client_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/client_lwrp.rb
@@ -9,5 +9,5 @@ sensu_client 'lwrp_client' do
   registration('handler' => 'register_client')
   deregister true
   deregistration('handler' => 'deregister_client')
-  additional('bacon' => true, 'beer' => {'variety' => 'cold'})
+  additional('bacon' => true, 'beer' => { 'variety' => 'cold' })
 end

--- a/test/cookbooks/sensu-test/recipes/default.rb
+++ b/test/cookbooks/sensu-test/recipes/default.rb
@@ -41,9 +41,6 @@ include_recipe "sensu::api_service"
 include_recipe "sensu::client_service"
 
 # ServerSpec dependencies
-
-if platform?("ubuntu")
-  package "net-tools"
-end
+package "net-tools" if platform?("ubuntu")
 
 include_recipe "sensu-test::gem_lwrp"

--- a/test/cookbooks/sensu-test/recipes/enterprise.rb
+++ b/test/cookbooks/sensu-test/recipes/enterprise.rb
@@ -37,7 +37,4 @@ include_recipe "sensu::redis"
 include_recipe "sensu::enterprise_service"
 
 # ServerSpec dependencies
-
-if platform?("ubuntu")
-  package "net-tools"
-end
+package "net-tools" if platform?("ubuntu")

--- a/test/cookbooks/sensu-test/recipes/enterprise_dashboard.rb
+++ b/test/cookbooks/sensu-test/recipes/enterprise_dashboard.rb
@@ -33,7 +33,4 @@ include_recipe "sensu::enterprise_dashboard"
 include_recipe "sensu::enterprise_dashboard_service"
 
 # ServerSpec dependencies
-
-if platform?("ubuntu")
-  package "net-tools"
-end
+package "net-tools" if platform?("ubuntu")

--- a/test/cookbooks/sensu-test/recipes/run_state_helpers.rb
+++ b/test/cookbooks/sensu-test/recipes/run_state_helpers.rb
@@ -1,3 +1,4 @@
+# rubocop:disable LineLength
 #
 # Cookbook Name:: sensu-test
 # Recipe:: run_state_helpers

--- a/test/integration/asset/serverspec/asset_spec.rb
+++ b/test/integration/asset/serverspec/asset_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-%w[
+%w(
   check-http.rb
   check-haproxy.rb
   check-banner.rb
   check-socket.rb
   check-dns.rb
-].each do |plugin|
+).each do |plugin|
   describe file(File.join(sensu_directory, "plugins", plugin)) do
     it { should be_file }
     it { should be_mode 755 } unless windows?
@@ -24,7 +24,7 @@ end
 
 profiler_extension = windows? ? 'wmi_metrics.rb' : 'system_profile.rb'
 
-describe file(File.join(sensu_directory , "extensions", profiler_extension)) do
+describe file(File.join(sensu_directory, "extensions", profiler_extension)) do
   it { should be_file }
   it { should be_mode 755 } unless windows?
   it { should be_owned_by "root" }

--- a/test/integration/run-state-helpers/serverspec/run_state_helpers_spec.rb
+++ b/test/integration/run-state-helpers/serverspec/run_state_helpers_spec.rb
@@ -12,7 +12,6 @@ set :backend, :exec
   '/etc/rabbitmq/ssl/client/cert.pem' => 'e29124436dec99a0a3126f61a742605d9c3cbf77',
   '/etc/rabbitmq/ssl/client/key.pem' => '43caa67add519458b1580dcc3a29b16335d49a15'
 }.each_pair do |pem, fingerprint|
-
   # The INVALID strings from sensu::ssl data bag item fixture should not be present.
   describe file(pem) do
     its(:content) { should_not match /INVALID/ }

--- a/test/unit/check_spec.rb
+++ b/test/unit/check_spec.rb
@@ -21,7 +21,6 @@ describe 'sensu-test::good_checks' do
       :standalone => nil
     )
   end
-
 end
 
 describe 'sensu-test::bad_check_name' do

--- a/test/unit/common_examples.rb
+++ b/test/unit/common_examples.rb
@@ -1,5 +1,4 @@
 RSpec.shared_examples 'sensu default recipe' do
-
   it "creates the log directory" do
     expect(chef_run).to create_directory(log_directory).with(
       :owner => 'sensu',
@@ -9,12 +8,7 @@ RSpec.shared_examples 'sensu default recipe' do
     )
   end
 
-  %w[
-      conf.d
-      plugins
-      handlers
-      extensions
-    ].each do |dir|
+  %w(conf.d plugins handlers extensions).each do |dir|
     it "creates the #{dir} directory" do
       expect(chef_run).to create_directory(File.join(sensu_directory, dir))
     end
@@ -34,9 +28,8 @@ RSpec.shared_examples 'sensu default recipe' do
   end
 
   context 'ssl is disabled' do
-
     before do
-      chef_run.node.override["sensu"]["use_ssl"] = false
+      chef_run.node.override['sensu']['use_ssl'] = false
       chef_run.converge(described_recipe)
     end
 
@@ -52,5 +45,4 @@ RSpec.shared_examples 'sensu default recipe' do
   it "writes a base sensu configuration using sensu_base_config" do
     expect(chef_run).to create_sensu_base_config(chef_run.node.name)
   end
-
 end

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -11,7 +11,7 @@ describe "sensu::default" do
 
     context "when running on ubuntu linux" do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
+        ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |_node, server|
           server.create_data_bag("sensu", ssl_data_bag_item)
         end.converge(described_recipe)
       end
@@ -34,7 +34,7 @@ describe "sensu::default" do
         let(:chef_run) do
           ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
             server.create_data_bag("sensu", ssl_data_bag_item)
-            node.override["sensu"]["apt_repo_codename"] = "dory"
+            node.override['sensu']['apt_repo_codename'] = "dory"
           end.converge(described_recipe)
         end
 
@@ -46,7 +46,7 @@ describe "sensu::default" do
 
     context "when running on rhel linux" do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(:platform => "redhat", :version => "7.3") do |node, server|
+        ChefSpec::ServerRunner.new(:platform => "redhat", :version => "7.3") do |_node, server|
           server.create_data_bag("sensu", ssl_data_bag_item)
         end.converge(described_recipe)
       end
@@ -69,7 +69,7 @@ describe "sensu::default" do
         let(:chef_run) do
           ChefSpec::ServerRunner.new(:platform => "redhat", :version => "7.3") do |node, server|
             server.create_data_bag("sensu", ssl_data_bag_item)
-            node.set["sensu"]["yum_repo_releasever"] = "dory"
+            node.set['sensu']['yum_repo_releasever'] = "dory"
           end.converge(described_recipe)
         end
 
@@ -81,7 +81,7 @@ describe "sensu::default" do
 
     context "when running on aix" do
       let(:chef_run) do
-        ChefSpec::ServerRunner.new(:platform => "aix", :version => "7.1") do |node, server|
+        ChefSpec::ServerRunner.new(:platform => "aix", :version => "7.1") do |_node, server|
           server.create_data_bag("sensu", ssl_data_bag_item)
         end.converge(described_recipe)
       end
@@ -111,7 +111,7 @@ describe "sensu::default" do
       ) do |node, server|
         server.create_data_bag("sensu", ssl_data_bag_item)
         node.override["lsb"] = {}
-        node.override["sensu"]["windows"]["dotnet_major_version"] = 3
+        node.override['sensu']['windows']['dotnet_major_version'] = 3
       end.converge(described_recipe)
     end
 
@@ -127,7 +127,7 @@ describe "sensu::default" do
 
     context "when install_dotnet is false" do
       it "does not include a recipe from the ms_dotnet cookbook" do
-        chef_run.node.override["sensu"]["windows"]["install_dotnet"] = false
+        chef_run.node.override['sensu']['windows']['install_dotnet'] = false
         chef_run.converge(described_recipe)
         expect(chef_run).to_not include_recipe(dotnet_recipe)
       end
@@ -139,5 +139,4 @@ describe "sensu::default" do
 
     it_behaves_like('sensu default recipe')
   end
-
 end

--- a/test/unit/enterprise_repo.rb
+++ b/test/unit/enterprise_repo.rb
@@ -18,7 +18,7 @@ describe "sensu::_enterprise_repo" do
     context "apt platforms" do
       let(:chef_run) do
         ChefSpec::ServerRunner.new(:platform => "ubuntu", :version => "16.04") do |node, server|
-          node.override["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          node.override['sensu']['enterprise']['use_unstable_repo'] = true unless repo_designation == 'stable'
           server.create_data_bag("sensu", data_bag_item)
         end.converge(described_recipe)
       end
@@ -29,14 +29,14 @@ describe "sensu::_enterprise_repo" do
             :uri => "http://chefspec:moartests!@enterprise.sensuapp.com/apt",
             :key => "http://chefspec:moartests!@enterprise.sensuapp.com/apt/pubkey.gpg",
             :distribution => "sensu-enterprise",
-            :components => repo_designation == "unstable" ?  ["unstable"] : ["main"]
+            :components => repo_designation == "unstable" ? ['unstable'] : ['main']
           )
         end
       end
 
       context "using custom host with #{repo_designation} repo" do
         before do
-          chef_run.node.override["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.node.override['sensu']['enterprise']['repo_host'] = 'chefspec.example.com'
           chef_run.converge(described_recipe)
         end
 
@@ -45,17 +45,16 @@ describe "sensu::_enterprise_repo" do
             :uri => "http://chefspec:moartests!@chefspec.example.com/apt",
             :key => "http://chefspec:moartests!@chefspec.example.com/apt/pubkey.gpg",
             :distribution => "sensu-enterprise",
-            :components => repo_designation == "unstable" ?  ["unstable"] : ["main"]
+            :components => repo_designation == "unstable" ? ['unstable'] : ['main']
           )
         end
       end
     end
 
     context "yum platforms" do
-
       let(:chef_run) do
         ChefSpec::ServerRunner.new(:platform => "centos", :version => "6.6") do |node, server|
-          node.override["sensu"]["enterprise"]["use_unstable_repo"] = true unless repo_designation == "stable"
+          node.override['sensu']['enterprise']['use_unstable_repo'] = true unless repo_designation == 'stable'
           server.create_data_bag("sensu", data_bag_item)
         end.converge(described_recipe)
       end
@@ -80,7 +79,7 @@ describe "sensu::_enterprise_repo" do
 
       context "using custom host with #{repo_designation} repo" do
         before do
-          chef_run.node.override["sensu"]["enterprise"]["repo_host"] = "chefspec.example.com"
+          chef_run.node.override['sensu']['enterprise']['repo_host'] = 'chefspec.example.com'
           chef_run.converge(described_recipe)
         end
 
@@ -92,6 +91,5 @@ describe "sensu::_enterprise_repo" do
         end
       end
     end
-
   end
 end

--- a/test/unit/libraries/sensu_helpers_spec.rb
+++ b/test/unit/libraries/sensu_helpers_spec.rb
@@ -3,7 +3,6 @@ require 'fauxhai'
 require_relative '../../../libraries/sensu_helpers.rb'
 
 describe Sensu::Helpers do
-
   let(:node) { Fauxhai.mock(:platform => 'ubuntu', :version => '14.04').data }
   let(:unix_omnibus_gem_path) { '/opt/sensu/embedded/bin/gem' }
   let(:windows_omnibus_gem_path) { 'c:\opt\sensu\embedded\bin\gem.bat' }
@@ -55,7 +54,6 @@ describe Sensu::Helpers do
       end
 
       context 'without omnibus ruby available' do
-
         before do
           allow(File).to receive(:exists?).with(unix_omnibus_gem_path).and_return(false)
           allow(File).to receive(:exists?).with(windows_omnibus_gem_path).and_return(false)
@@ -84,7 +82,6 @@ describe Sensu::Helpers do
       end
 
       context 'without omnibus ruby available' do
-
         before do
           allow(File).to receive(:exists?).with(unix_omnibus_gem_path).and_return(false)
           allow(File).to receive(:exists?).with(windows_omnibus_gem_path).and_return(false)

--- a/test/unit/libraries/sensu_json_file_spec.rb
+++ b/test/unit/libraries/sensu_json_file_spec.rb
@@ -2,10 +2,9 @@ require 'chefspec'
 require_relative '../../../libraries/sensu_json_file.rb'
 
 describe 'Sensu::JSONFile' do
-
   let(:config) do
     {
-      "client" => { "name" => "test", "address" => "localhost", "subscriptions" => [ "test" ] },
+      "client" => { "name" => "test", "address" => "localhost", "subscriptions" => ["test"] },
       "rabbitmq" => { "host" => "172.16.100.100", "port" => 5671, "vhost" => "/sensu", "user" => "sensu", "password" => "sensu" }
     }
   end
@@ -18,7 +17,6 @@ describe 'Sensu::JSONFile' do
   end
 
   describe ".load_json" do
-   
     it 'returns a non-empty hash' do
       result = Sensu::JSONFile.load_json(stubbed_file_path)
       expect(result).to be_a(Hash)
@@ -59,5 +57,4 @@ describe 'Sensu::JSONFile' do
       expect(result).to eq(true)
     end
   end
-
 end

--- a/test/unit/lwrps/base_config_spec.rb
+++ b/test/unit/lwrps/base_config_spec.rb
@@ -2,7 +2,6 @@ require_relative "../spec_helper"
 require 'json'
 
 describe "sensu_base_config" do
-
   let(:single_broker_config) do
     {
       "host" => "10.0.0.6",
@@ -22,7 +21,7 @@ describe "sensu_base_config" do
 
   let(:multiple_broker_config) do
     {
-      "hosts" => [ "10.0.0.6", "10.0.0.7", "10.0.0.8" ],
+      "hosts" => ["10.0.0.6", "10.0.0.7", "10.0.0.8"],
       "host" => "192.168.1.1",
       "port" => 5671,
       "vhost" => "/sensu",
@@ -85,12 +84,12 @@ describe "sensu_base_config" do
     ChefSpec::SoloRunner.new(
       :platform => "ubuntu",
       :version => "14.04",
-      :step_into => ['sensu_base_config', 'sensu_json_file']
+      :step_into => %w(sensu_base_config sensu_json_file)
     ) do |node|
-      node.override["sensu"]["transport"]["chefspec"] = true
-      node.override["sensu"]["redis"]["chefspec"] = true
-      node.override["sensu"]["api"]["chefspec"] = true
-      node.override["sensu"]["rabbitmq"] = single_broker_config
+      node.override['sensu']['transport']["chefspec"] = true
+      node.override['sensu']['redis']["chefspec"] = true
+      node.override['sensu']['api']["chefspec"] = true
+      node.override['sensu']['rabbitmq'] = single_broker_config
     end.converge("sensu::default")
   end
 
@@ -101,7 +100,7 @@ describe "sensu_base_config" do
   end
 
   context "base configuration is derived from node attributes" do
-    %w[ transport redis api ].each do |kw|
+    %w( transport redis api ).each do |kw|
       it "#{kw} node attributes are present in base configuration" do
         content = JSON.parse(base_config_json.content)
         expect(content[kw]["chefspec"]).to eq(true)
@@ -112,24 +111,22 @@ describe "sensu_base_config" do
   context "single rabbitmq host provided" do
     it "yields a rabbitmq array with a single hash" do
       content = JSON.parse(base_config_json.content)
-      expect(content["rabbitmq"].is_a?(Array)).to eq(true)
-      expect(content["rabbitmq"][0].is_a?(Hash)).to eq(true)
-      expect(content["rabbitmq"][0]).to eq(single_broker_config)
+      expect(content['rabbitmq'].is_a?(Array)).to eq(true)
+      expect(content['rabbitmq'][0].is_a?(Hash)).to eq(true)
+      expect(content['rabbitmq'][0]).to eq(single_broker_config)
     end
   end
 
   context "multiple rabbitmq hosts provided" do
-
     before do
-      chef_run.node.override["sensu"]["rabbitmq"] = multiple_broker_config
+      chef_run.node.override['sensu']['rabbitmq'] = multiple_broker_config
       chef_run.converge("sensu::default")
     end
 
     it "yields a rabbitmq array containing multiple brokers" do
       content = JSON.parse(base_config_json.content)
-      expect(content["rabbitmq"].is_a?(Array)).to eq(true)
-      expect(content["rabbitmq"]).to eq(multiple_broker_json)
+      expect(content['rabbitmq'].is_a?(Array)).to eq(true)
+      expect(content['rabbitmq']).to eq(multiple_broker_json)
     end
   end
-
 end

--- a/test/unit/lwrps/client_spec.rb
+++ b/test/unit/lwrps/client_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 describe 'sensu_client with minimum required attributes' do
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      :step_into => %w[sensu_client sensu_json_file],
+      :step_into => %w(sensu_client sensu_json_file),
       :platform => "ubuntu",
       :version => "14.04"
     ).converge('sensu-test::client_lwrp_defaults')
@@ -29,7 +29,7 @@ describe 'sensu_client with minimum required attributes' do
   end
 
   it 'does not provide configuration for unconfigured optional attributes' do
-    %w[ deregister deregistration keepalive keepalives redact registration safe_mode socket ].each do
+    %w( deregister deregistration keepalive keepalives redact registration safe_mode socket ).each do
       |attr|
       expect(minimal_client_content.key?(attr)).to eq(false)
     end
@@ -41,11 +41,11 @@ describe 'sensu_client with optional attributes' do
 
   let(:chef_run) do
     ChefSpec::SoloRunner.new(
-      :step_into => %w[sensu_client sensu_json_file],
+      :step_into => %w(sensu_client sensu_json_file),
       :platform => "ubuntu",
       :version => "14.04"
     ) do |node|
-      node.override["sensu"]["directory"] = sensu_dir
+      node.override['sensu']['directory'] = sensu_dir
     end.converge('sensu-test::client_lwrp')
   end
 
@@ -111,5 +111,4 @@ describe 'sensu_client with optional attributes' do
     expect(client_content['bacon']).to eq(true)
     expect(client_content['beer']).to eq('variety' => 'cold')
   end
-
 end

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -49,5 +49,4 @@ describe 'sensu_gem' do
       expect(chef_run).to upgrade_gem_package('sensu-plugins-disk-checks').with(:version => '1.1.2')
     end
   end
-
 end

--- a/test/unit/lwrps/json_file_spec.rb
+++ b/test/unit/lwrps/json_file_spec.rb
@@ -15,7 +15,7 @@ describe 'sensu_json_file' do
   end
 
   it 'creates the /etc/sensu directory using value of directory_mode attribute' do
-    expect(chef_run).to create_directory('/etc/sensu').with({ :mode => test_directory_mode })
+    expect(chef_run).to create_directory('/etc/sensu').with(:mode => test_directory_mode)
   end
 
   it 'creates a "pretty" json file with the provided content' do
@@ -23,5 +23,4 @@ describe 'sensu_json_file' do
       JSON.pretty_generate(test_content)
     )
   end
-
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Quite noisy Rubocop complaints about things like double-quote non-interpolated strings, square-bracket-delimited arrays, and the like.

## Motivation and Context
My dev environment run rubocop and foodcritic as a pre-commit hook; to ingest vendor changes, these fixes are required.

## How Has This Been Tested?
Converged when encapsulated in a wrapper cookbook.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Linter fixes

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.