### PR TITLE
adding source property to gem provider with upgrade action

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "support@sensuapp.com"
 license          "Apache-2.0"
 description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "4.0.6"
+version          "4.0.7"
 
 # available @ https://supermarket.chef.io/cookbooks/apt
 depends "apt", ">= 2.0"

--- a/providers/gem.rb
+++ b/providers/gem.rb
@@ -13,6 +13,7 @@ action :upgrade do
   g = gem_package new_resource.name do
     gem_binary Sensu::Helpers.gem_binary
     version new_resource.version
+    source  new_resource.source
     options new_resource.options
     action :upgrade
   end

--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -31,6 +31,13 @@ sensu_gem 'sensu-plugins-memory-checks' do
   action :install
 end
 
+# for testing upgrade action with source
+sensu_gem 'sensu-plugins-memory-checks' do
+  source mem_checks
+  version '1.1.2'
+  action :upgrade
+end
+
 # for testing upgrade action
 sensu_gem 'sensu-plugins-disk-checks' do
   version '1.1.2'

--- a/test/unit/lwrps/gem_spec.rb
+++ b/test/unit/lwrps/gem_spec.rb
@@ -29,6 +29,12 @@ describe 'sensu_gem' do
       it 'installs the specified gem package from the specified source' do
         expect(chef_run).to install_gem_package('sensu-plugins-memory-checks').with(:source => '/tmp/sensu-plugins-memory-checks.gem')
       end
+     it 'upgrades the specified gem package from the specified source' do
+        expect(chef_run).to upgrade_gem_package('sensu-plugins-memory-checks').with(
+          :source => '/tmp/sensu-plugins-memory-checks.gem',
+          :version => '1.1.2'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Source property added to the sensu_gem provider's upgrade action.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu_gem provider did not allow for a source property when using the upgrade action.
This fix adds the source option to the sensu_gem provider upgrade action.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
unit tests
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.