### PR TITLE
Flush yum cache

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,6 +33,7 @@ default["sensu"]["client_deregister_handler"] = nil
 
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
+default['sensu']['yum_flush_cache'] = nil
 default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
 default["sensu"]["aix_package_root_url"] = "https://sensu.global.ssl.fastly.net/aix"
 default["sensu"]["add_repo"] = true

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -85,7 +85,7 @@ when "rhel", "fedora", "amazon"
       node["sensu"]["version_suffix"]
     )}
     allow_downgrade true
-    flush_cache [ :before ]
+    flush_cache node['sensu']['yum_flush_cache'] unless node['sensu']['yum_flush_cache'].nil?
     notifies :create, "ruby_block[sensu_service_trigger]"
   end
 else

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -85,6 +85,7 @@ when "rhel", "fedora", "amazon"
       node["sensu"]["version_suffix"]
     )}
     allow_downgrade true
+    flush_cache [ :before ]
     notifies :create, "ruby_block[sensu_service_trigger]"
   end
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Flush yum cache before installing the sensu rpm package.

## Motivation and Context
Chef caches the yum package database in memory in order to speed up recipe execution. When updating the sensu version attribute, sometimes chef fails because it doesn't recognize the version.

## How Has This Been Tested?
ran kitchen converge and verify on default-centos-68 and default-centos-73 platforms

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.