### PR TITLE
allow specifying `source` to `check` provider

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,7 @@ suites:
     run_list:
       - recipe[sensu-test::ensure_group]
       - recipe[sensu::default]
+      - recipe[sensu-test::good_checks]
     attributes:
       sensu:
         group: nogroup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Added
+* native support for proxy client checks (formerly known as JIT) to the `check` provider by accepting a `source` parameter (@majormoses)
+* misc development dependencies that were missing (@majormoses)
+
 ## [4.1.0] - 2017-12-14
 ### Added
 * ability to control `yum_package`'s `flush_cache` parameter by specifying `node['sensu']['yum_flush_cache']`. This allows you to control chefs in memory cache during a `chef-client` run. For more information see [here](https://docs.chef.io/resource_yum.html).

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,18 @@
 source "https://rubygems.org"
 
 group :develop do
-  gem "stove", "~> 5.0"
-  gem "guard"
-  gem "guard-foodcritic"
-  gem "guard-rspec"
-  gem "guard-rubocop"
+  gem 'berkshelf', '~> 6.3'
+  gem 'guard'
+  gem 'guard-foodcritic'
+  gem 'guard-rspec'
+  gem 'guard-rubocop'
+  gem 'kitchen-docker', '~> 2.6'
+  gem 'kitchen-localhost', '~> 0.3'
+  gem 'kitchen-vagrant', '~> 1.2'
+  gem 'serverspec', '~> 2.36.1'
+  gem 'stove', '~> 5.0'
+  gem 'test-kitchen', '~> 1.6'
+  gem 'winrm'
+  gem 'winrm-fs'
+  gem 'winrm-elevated'
 end

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -14,8 +14,20 @@ action :create do
   check = Sensu::Helpers.select_attributes(
     new_resource,
     %w[
-      type command timeout subscribers standalone aggregate aggregates handle
-      handlers publish subdue low_flap_threshold high_flap_threshold
+      aggregate
+      aggregates
+      command
+      handle
+      handlers
+      high_flap_threshold
+      low_flap_threshold
+      publish
+      standalone
+      source
+      subdue
+      subscribers
+      timeout
+      type
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -13,6 +13,7 @@ attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array
 attribute :publish, :kind_of => [TrueClass, FalseClass]
+attribute :source, :kind_of => String
 attribute :subdue, :kind_of => Hash
 attribute :low_flap_threshold, :kind_of => Integer
 attribute :high_flap_threshold, :kind_of => Integer

--- a/test/cookbooks/sensu-test/recipes/good_checks.rb
+++ b/test/cookbooks/sensu-test/recipes/good_checks.rb
@@ -13,3 +13,11 @@ end
 sensu_check "removed_check" do
   action :delete
 end
+
+# proxy client
+sensu_check "valid_proxy_client_check" do
+  interval 20
+  command 'true'
+  standalone true
+  source 'some-site-being-monitored'
+end

--- a/test/integration/default/serverspec/check_spec.rb
+++ b/test/integration/default/serverspec/check_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'serverspec'
+require 'json'
+set :backend, :exec
+
+unless windows?
+  describe file('/etc/sensu/conf.d/checks/valid_proxy_client_check.json') do
+    it { should be_file }
+    its(:content_as_json) do
+      should include('checks' =>
+             include('valid_proxy_client_check' =>
+             include(
+               'command' => 'true',
+               'standalone' => true,
+               'source' => 'some-site-being-monitored',
+               'interval' => 20
+             )))
+    end
+  end
+end


### PR DESCRIPTION
This enables creating proxy clients (previously known as JIT).

Signed-off-by: Ben Abrams <me@benabrams.it>

## Description
Added ability to specify `source` parameter as a first class citizen of the `check` provider to enable proxy/JIT clients.

## Motivation and Context

#417 

## How Has This Been Tested?
I added a `serverspec` test to validate that the check gets created correctly (at least from my understanding of how JIT clients work).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.