### PR TITLE
Secure Package Installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to track changes made in recent versions of the Sensu
 cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
+### Security
+* Enable gpg check for all linux repo installs using a key downloaded over HTTPS. Download windows MSI over HTTPS. #578 (@mike-stewart)
 
 ## [4.2.0] - 2018-02-16
 ### Added

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,9 +34,11 @@ default["sensu"]["client_deregister_handler"] = nil
 default["sensu"]["apt_repo_url"] = "http://repositories.sensuapp.org/apt"
 default["sensu"]["yum_repo_url"] = "http://repositories.sensuapp.org"
 default['sensu']['yum_flush_cache'] = nil
-default["sensu"]["msi_repo_url"] = "http://repositories.sensuapp.org/msi"
+default["sensu"]["msi_repo_url"] = "https://repositories.sensuapp.org/msi"
 default["sensu"]["aix_package_root_url"] = "https://sensu.global.ssl.fastly.net/aix"
 default["sensu"]["add_repo"] = true
+default['sensu']['apt_key_url'] = 'https://sensu.global.ssl.fastly.net/apt/pubkey.gpg'
+default['sensu']['yum_key_url'] = 'https://sensu.global.ssl.fastly.net/yum/pubkey.gpg'
 
 # transport
 default["sensu"]["transport"]["reconnect_on_error"] = true

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -25,7 +25,7 @@ when "debian"
 
   apt_repository "sensu" do
     uri node["sensu"]['apt_repo_url']
-    key "#{node['sensu']['apt_repo_url']}/pubkey.gpg"
+    key node['sensu']['apt_key_url']
     distribution node["sensu"]["apt_repo_codename"] || node["lsb"]["codename"]
     components node["sensu"]["use_unstable_repo"] ? ["unstable"] : ["main"]
     action :add
@@ -49,9 +49,9 @@ when "suse"
     repo_name 'sensu'
     repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"
     uri "#{node['sensu']['yum_repo_url']}/#{repo}/7/x86_64/"
+    gpgkey node['sensu']['yum_key_url']
   end
-
-  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
+  repo.gpgcheck(true) if repo.respond_to?(:gpgcheck)
 
   # As of 0.27 we need to suffix the version string with the platform major
   # version, e.g. ".el7". Override default via node["sensu"]["version_suffix"]
@@ -70,10 +70,11 @@ when "rhel", "fedora", "amazon"
     repo = node["sensu"]["use_unstable_repo"] ? "yum-unstable" : "yum"
     releasever_string = node["sensu"]["yum_repo_releasever"] || "$releasever"
     baseurl "#{node['sensu']['yum_repo_url']}/#{repo}/#{releasever_string}/$basearch/"
+    gpgkey node['sensu']['yum_key_url']
     action :add
     only_if { node["sensu"]["add_repo"] }
   end
-  repo.gpgcheck(false) if repo.respond_to?(:gpgcheck)
+  repo.gpgcheck(true) if repo.respond_to?(:gpgcheck)
 
   # As of 0.27 we need to suffix the version string with the platform major
   # version, e.g. ".el7". Override default via node["sensu"]["version_suffix"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes sensu/sensu-chef/issues/578. This secures the package installation against MITM attacks for linux by downloading the GPG key over HTTPS. 

I didn't change the linux repo URLs themselves as there is generally less benefit in downloading the packages over HTTPS given GPG checks. It requires an additional package in some cases, and it can get in the way of caching.

For Windows, I changed the package URL, as I'm not aware of a method to check package signatures there. 

## Motivation and Context
See sensu/sensu-chef#578.

## How Has This Been Tested?
Executed tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.