### PR TITLE
added chef 13 compatibility by pulling in latest redisio cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Added
+- pulling in latest release `redisio` cookbook to fix chef 13 compatibility (@majormoses)
+
 ## [4.2.1] - 2018-03-04
 ### Security
 * Enable gpg check for all linux repo installs using a key downloaded over HTTPS. Download windows MSI over HTTPS. #578 (@mike-stewart)

--- a/metadata.rb
+++ b/metadata.rb
@@ -22,7 +22,7 @@ depends "ms_dotnet", ">= 2.6.1"
 depends "rabbitmq", ">= 2.0.0"
 
 # available @ https://supermarket.chef.io/cookbooks/redisio
-depends "redisio", ">= 1.7.0"
+depends "redisio", ">= 2.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
 suggests "chef-vault", ">= 1.3.1"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pull in new `redisio` cookbook to better support chef 13

## Motivation and Context
Due to an issue with the upstream `redisio` cookbook the current `sensu` cookbook fails on chef 13. A contribution was merged way back https://github.com/brianbianco/redisio/pull/350 but never released. The cookbook has been not well maintained recently. I reached out to the maintainer and got access to cut a release and push it to the supermarket. This pulls in those changes.

## How Has This Been Tested?
I have not done any testing but there is a comment [here](https://github.com/brianbianco/redisio/pull/350#issuecomment-343775628) indicating it should work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.