### PR TITLE
Require Chef 12.14+ and remove apt/yum dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,10 @@ See CODE_OF_CONDUCT.md, CONTRIBUTING.md and TESTING.md documents.
 
 ### Chef
 
-* Chef 12+
+* Chef 12.14+
 
 ### Cookbooks
 
-* [APT](https://supermarket.chef.io/cookbooks/apt)
-* [YUM](https://supermarket.chef.io/cookbooks/yum)
 * [Windows](https://supermarket.chef.io/cookbooks/windows)
 * [RabbitMQ](https://supermarket.chef.io/cookbooks/rabbitmq)
 * [RedisIO](https://supermarket.chef.io/cookbooks/redisio)

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,6 @@ description      "Installs/Configures Sensu"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "4.3.1"
 
-# available @ https://supermarket.chef.io/cookbooks/apt
-depends "apt", ">= 2.0"
-
-# available @ https://supermarket.chef.io/cookbooks/yum
-depends "yum", ">= 3.0"
-
 # available @ https://supermarket.chef.io/cookbooks/windows
 depends "windows", ">= 1.36"
 
@@ -48,4 +42,4 @@ end
 
 source_url 'https://github.com/sensu/sensu-chef'
 issues_url 'https://github.com/sensu/sensu-chef/issues'
-chef_version '>= 12.0'
+chef_version '>= 12.14'

--- a/recipes/_enterprise_repo.rb
+++ b/recipes/_enterprise_repo.rb
@@ -21,7 +21,7 @@ repository_url = case credentials.nil?
 
 case node["platform_family"]
 when "debian"
-  include_recipe "apt"
+  package "apt-transport-https"
 
   apt_repository "sensu-enterprise" do
     uri File.join(repository_url, "apt")

--- a/recipes/_linux.rb
+++ b/recipes/_linux.rb
@@ -21,7 +21,7 @@ platform_family = node["platform_family"]
 
 case platform_family
 when "debian"
-  include_recipe "apt"
+  package "apt-transport-https"
 
   apt_repository "sensu" do
     uri node["sensu"]['apt_repo_url']


### PR DESCRIPTION
## Description

Remove the legacy apt and yum dependencies by requiring Chef 12.14 which
came out Sept 2016.

## Motivation and Context

Chef 12 is technically end of life, and it seems
reasonable to require people to at least be on one of the later
releases.

By removing these deps we speed up Chef runs by requiring fewer cookbooks to be pulled to the local nodes.

## How Has This Been Tested?

Ran on my home server

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.