### PR TITLE
adding `ttl` as a first class check attribute to lwrp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Added
+- native support for `ttl` checks (@majormoses)
+
 ## [4.3.1] - 2018-04-11
 ### Fixed
 - reverted #468 per #564 (@majormoses)

--- a/README.md
+++ b/README.md
@@ -317,6 +317,26 @@ sensu_check "redis_process" do
 end
 ```
 
+The `sensu_check` provider supports the following attributes:
+
+* additional
+* aggregate
+* aggregates
+* command
+* handle
+* handlers
+* high_flap_threshold
+* low_flap_threshold
+* publish
+* source
+* subdue
+* standalone
+* subscribers
+* timeout
+* ttl
+* type
+
+
 ### Define a filter
 
 ```ruby

--- a/providers/check.rb
+++ b/providers/check.rb
@@ -27,6 +27,7 @@ action :create do
       subdue
       subscribers
       timeout
+      ttl
       type
     ]
   ).merge("interval" => new_resource.interval).merge(new_resource.additional)

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -2,22 +2,23 @@ actions :create, :delete
 default_action :create
 
 # 'standard' and 'status' types are synonymous
-attribute :type, :kind_of => String, :equal_to => %w[standard status metric]
+attribute :additional, :kind_of => Hash, :default => Hash.new
 attribute :command, :kind_of => String, :required => true
-attribute :timeout, :kind_of => Integer
-attribute :subscribers, :kind_of => Array
-attribute :standalone, :kind_of => [TrueClass, FalseClass]
 attribute :aggregate, :kind_of => [String, TrueClass, FalseClass]
 attribute :aggregates, :kind_of => Array
 attribute :interval, :default => 60
 attribute :handle, :kind_of => [TrueClass, FalseClass]
 attribute :handlers, :kind_of => Array
+attribute :high_flap_threshold, :kind_of => Integer
+attribute :low_flap_threshold, :kind_of => Integer
 attribute :publish, :kind_of => [TrueClass, FalseClass]
 attribute :source, :kind_of => String
+attribute :standalone, :kind_of => [TrueClass, FalseClass]
 attribute :subdue, :kind_of => Hash
-attribute :low_flap_threshold, :kind_of => Integer
-attribute :high_flap_threshold, :kind_of => Integer
-attribute :additional, :kind_of => Hash, :default => Hash.new
+attribute :subscribers, :kind_of => Array
+attribute :timeout, :kind_of => Integer
+attribute :ttl, :kind_of => Integer
+attribute :type, :kind_of => String, :equal_to => %w[standard status metric]
 
 def after_created
   unless name =~ /^[\w\.-]+$/

--- a/test/cookbooks/sensu-test/recipes/good_checks.rb
+++ b/test/cookbooks/sensu-test/recipes/good_checks.rb
@@ -20,4 +20,5 @@ sensu_check "valid_proxy_client_check" do
   command 'true'
   standalone true
   source 'some-site-being-monitored'
+  ttl 40
 end

--- a/test/integration/default/serverspec/check_spec.rb
+++ b/test/integration/default/serverspec/check_spec.rb
@@ -13,7 +13,8 @@ unless windows?
                'command' => 'true',
                'standalone' => true,
                'source' => 'some-site-being-monitored',
-               'interval' => 20
+               'interval' => 20,
+               'ttl' => 40
              )))
     end
   end


### PR DESCRIPTION
Signed-off-by: Ben Abrams me@benabrams.it


## Description
Add first class support for TTL checks rather than specifying it in additional.

Misc Changes:
- sort the list of `sensu_check` attributes
- add list of attributes to the `README`

## Motivation and Context

Check TTLs are often used in conjunction with `proxy` (formerly JIT) client checks. This allows you to know when your proxy client has stopped reporting in.

sensu doc: https://docs.sensu.io/sensu-core/1.3/reference/checks/#check-attributes

![image](https://user-images.githubusercontent.com/3145127/39556722-4269b750-4e37-11e8-9ca9-6ef5d74ca0f0.png)


## How Has This Been Tested?
Added to existing proxy check as that is where it is most commonly used.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.