### PR TITLE
properly lock to minimum required version of chef client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Fixed
+- metadata now properly requires chef client to be `>= 13.3` this is a follow up to the v5.0.0 release which locked it at `>= 12.14` but after digging into it the change requires a newer version. As chef 12 is EOL we are gonna roll forward rather than backwards (@majormoses)
+
 ## [5.1.1] - 2018-05-30
 ### Fixed
 - version detection for server 2008 (@smcavallo)

--- a/metadata.rb
+++ b/metadata.rb
@@ -42,4 +42,4 @@ end
 
 source_url 'https://github.com/sensu/sensu-chef'
 issues_url 'https://github.com/sensu/sensu-chef/issues'
-chef_version '>= 12.14'
+chef_version '>= 13.3'

--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -69,7 +69,7 @@ describe "sensu::default" do
         let(:chef_run) do
           ChefSpec::ServerRunner.new(:platform => "redhat", :version => "7.3") do |node, server|
             server.create_data_bag("sensu", ssl_data_bag_item)
-            node.set["sensu"]["yum_repo_releasever"] = "dory"
+            node.override["sensu"]["yum_repo_releasever"] = "dory"
           end.converge(described_recipe)
         end
 


### PR DESCRIPTION
This fixes #605 which is an unfortunate scenerio

Signed-off-by: Ben Abrams <me@benabrams.it>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Properly locks to `13.3 >=` as thats what the code actually needs. See issue for more details.

## Motivation and Context
Fixes #605 

## How Has This Been Tested?
Has not

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.