### PR TITLE
serverside cookbooks should be suggested but not required

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,10 +13,10 @@ depends "windows", ">= 1.36"
 depends "ms_dotnet", ">= 2.6.1"
 
 # available @ https://supermarket.chef.io/cookbooks/rabbitmq
-depends "rabbitmq", ">= 2.0.0"
+suggests "rabbitmq", ">= 2.0.0"
 
 # available @ https://supermarket.chef.io/cookbooks/redisio
-depends "redisio", ">= 2.7.0"
+suggests "redisio", ">= 2.7.0"
 
 # available @ https://supermarket.chef.io/cookbooks/chef-vault
 suggests "chef-vault", ">= 1.3.1"


### PR DESCRIPTION
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>
Addresses https://github.com/sensu/sensu-chef/issues/616

## Description
since this cookbook gets applied to both sensu server components (server + api + rabbitmq + redis) and sensu clients, the cookbooks which the server components require should be opted into.

## Motivation and Context
allows consumers to opt-in for rabbitmq + redis cookbooks.  opting in means that they'll be required to maintain these cookbooks as part of their chef implementation.

## How Has This Been Tested?
normal testing as part of the PR process

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to change)

This is a breaking change.  Since the default is now opt-out, consumers would need to implement the dependency requirements in their wrapper cookbooks.

## Checklist:
- [ X] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [ ]X I have read the **CONTRIBUTING** document.