### PR TITLE
`sensu_gem` can now optionally specify `gem_package`

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -44,6 +44,7 @@ suites:
     run_list:
       - recipe[sensu-test::ensure_group]
       - recipe[sensu::default]
+      - recipe[sensu-test::gem_lwrp]
       - recipe[sensu-test::good_checks]
     attributes:
       sensu:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ cookbook. Please see HISTORY.md for changes from older versions of this project.
 
 ## [Unreleased]
 
+### Added
+- exposed `package_name` as an optional parameter to the `sensu_gem` resource in case you need to install multiple versions of a gem. (@majormoses)
+
 ## [5.3.0] - 2018-08-19
 ### Added
 - First class support for defining checks via cron syntax (@vbichov)

--- a/providers/gem.rb
+++ b/providers/gem.rb
@@ -4,6 +4,7 @@ action :install do
     version new_resource.version
     source  new_resource.source
     options new_resource.options
+    package_name new_resource.package_name unless new_resource.package_name.nil?
   end
 
   new_resource.updated_by_last_action(g.updated_by_last_action?)
@@ -15,6 +16,7 @@ action :upgrade do
     version new_resource.version
     source  new_resource.source
     options new_resource.options
+    package_name new_resource.package_name unless new_resource.package_name.nil?
     action :upgrade
   end
 
@@ -25,6 +27,7 @@ action :remove do
   g = gem_package new_resource.name do
     gem_binary Sensu::Helpers.gem_binary
     version new_resource.version
+    package_name new_resource.package_name unless new_resource.package_name.nil?
     action :remove
   end
 

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -4,3 +4,4 @@ default_action :install
 attribute :version, :kind_of => String
 attribute :source,  :kind_of => String
 attribute :options, :kind_of => [String, Hash]
+attribute :package_name, :kind_of => [String, NilClass], :default => nil

--- a/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
+++ b/test/cookbooks/sensu-test/recipes/gem_lwrp.rb
@@ -31,6 +31,13 @@ sensu_gem 'sensu-plugins-memory-checks' do
   action :install
 end
 
+# for testing the package proprty
+sensu_gem 'sensu-plugins-disk-checks-newer' do
+  action :install
+  version '3.1.0'
+  package_name 'sensu-plugins-disk-checks'
+end
+
 # for testing upgrade action with source
 sensu_gem 'sensu-plugins-memory-checks' do
   source mem_checks

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 sensu_pkg_name = windows? ? 'Sensu' : 'sensu'
 
+sensu_gem_bin = '/opt/sensu/embedded/bin/gem'
+
 describe package(sensu_pkg_name) do
   it { should be_installed }
 end
@@ -10,4 +12,8 @@ describe file(File.join(sensu_directory, "config.json")) do
   its(:content) { should match /"name": "test"/ }
   its(:content) { should_not match /"id": / }
   # it { should be_grouped_into('nogroup') } unless windows?
+end
+
+describe command("#{sensu_gem_bin} list | grep sensu-plugins-disk-checks") do
+  its('stdout') { should match(/3\.(\d+).\d+/)}
 end


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow setting `package_name` in `sensu_gem` so that you can install multiple versions of the same gem by allowing the name of the resource and the package can differ.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is helpful when you need multiple versions of the same plugin (or any gemfor that matter) by allowing the resource name and package name to differ.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
integration test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.